### PR TITLE
Add configurable key algorithm and signature algorithm support

### DIFF
--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/IssuerInfo.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/IssuerInfo.java
@@ -11,6 +11,8 @@ public final class IssuerInfo {
     private final Instant validFrom;
     private final Instant validUntil;
     private final Duration defaultLifespan;
+    private final KeyAlgorithm keyAlgorithm;
+    private final String signatureAlgorithm;
 
     private IssuerInfo(Builder builder) {
         this.subjectName = builder.subjectName;
@@ -19,6 +21,9 @@ public final class IssuerInfo {
                 : Instant.now().plus(1, ChronoUnit.DAYS);
         this.defaultLifespan = builder.defaultLifespan != null ? builder.defaultLifespan
                 : Duration.ofDays(1L);
+        this.keyAlgorithm = builder.keyAlgorithm != null ? builder.keyAlgorithm
+                : KeyAlgorithm.rsa(2048);
+        this.signatureAlgorithm = builder.signatureAlgorithm;
     }
 
     public static Builder builder() {
@@ -41,6 +46,17 @@ public final class IssuerInfo {
         return defaultLifespan;
     }
 
+    public KeyAlgorithm getKeyAlgorithm() {
+        return keyAlgorithm;
+    }
+
+    // Returns the explicitly configured signature algorithm, or the default
+    // implied by the key algorithm if none was set.
+    public String getEffectiveSignatureAlgorithm() {
+        return signatureAlgorithm != null ? signatureAlgorithm
+                : keyAlgorithm.defaultSignatureAlgorithm();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -48,12 +64,15 @@ public final class IssuerInfo {
         return Objects.equals(subjectName, that.subjectName)
                 && Objects.equals(validFrom, that.validFrom)
                 && Objects.equals(validUntil, that.validUntil)
-                && Objects.equals(defaultLifespan, that.defaultLifespan);
+                && Objects.equals(defaultLifespan, that.defaultLifespan)
+                && Objects.equals(keyAlgorithm, that.keyAlgorithm)
+                && Objects.equals(signatureAlgorithm, that.signatureAlgorithm);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(subjectName, validFrom, validUntil, defaultLifespan);
+        return Objects.hash(subjectName, validFrom, validUntil, defaultLifespan,
+                keyAlgorithm, signatureAlgorithm);
     }
 
     @Override
@@ -63,6 +82,8 @@ public final class IssuerInfo {
                 + ", validFrom=" + validFrom
                 + ", validUntil=" + validUntil
                 + ", defaultLifespan=" + defaultLifespan
+                + ", keyAlgorithm=" + keyAlgorithm
+                + ", signatureAlgorithm=" + signatureAlgorithm
                 + '}';
     }
 
@@ -71,6 +92,8 @@ public final class IssuerInfo {
         private Instant validFrom;
         private Instant validUntil;
         private Duration defaultLifespan;
+        private KeyAlgorithm keyAlgorithm;
+        private String signatureAlgorithm;
 
         private Builder() {
         }
@@ -92,6 +115,16 @@ public final class IssuerInfo {
 
         public Builder defaultLifespan(Duration defaultLifespan) {
             this.defaultLifespan = defaultLifespan;
+            return this;
+        }
+
+        public Builder keyAlgorithm(KeyAlgorithm keyAlgorithm) {
+            this.keyAlgorithm = keyAlgorithm;
+            return this;
+        }
+
+        public Builder signatureAlgorithm(String signatureAlgorithm) {
+            this.signatureAlgorithm = signatureAlgorithm;
             return this;
         }
 

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/IssuerInfo.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/IssuerInfo.java
@@ -124,6 +124,10 @@ public final class IssuerInfo {
         }
 
         public Builder signatureAlgorithm(String signatureAlgorithm) {
+            if (signatureAlgorithm != null && signatureAlgorithm.isBlank()) {
+                throw new IllegalArgumentException(
+                        "signatureAlgorithm must not be blank; pass null to use the default for the key algorithm");
+            }
             this.signatureAlgorithm = signatureAlgorithm;
             return this;
         }

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/KeyAlgorithm.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/KeyAlgorithm.java
@@ -1,0 +1,41 @@
+package com.elevenware.quickpki;
+
+import java.util.Objects;
+
+public sealed interface KeyAlgorithm permits KeyAlgorithm.Rsa, KeyAlgorithm.Ec {
+
+    static KeyAlgorithm rsa(int bits) {
+        return new Rsa(bits);
+    }
+
+    static KeyAlgorithm ec(String curve) {
+        return new Ec(curve);
+    }
+
+    String defaultSignatureAlgorithm();
+
+    record Rsa(int bits) implements KeyAlgorithm {
+        public Rsa {
+            if (bits < 2048) {
+                throw new IllegalArgumentException(
+                        "RSA key size must be at least 2048 bits, got " + bits);
+            }
+        }
+
+        @Override
+        public String defaultSignatureAlgorithm() {
+            return "SHA256withRSA";
+        }
+    }
+
+    record Ec(String curve) implements KeyAlgorithm {
+        public Ec {
+            Objects.requireNonNull(curve, "curve must not be null");
+        }
+
+        @Override
+        public String defaultSignatureAlgorithm() {
+            return "SHA256withECDSA";
+        }
+    }
+}

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/KeyAlgorithm.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/KeyAlgorithm.java
@@ -31,6 +31,9 @@ public sealed interface KeyAlgorithm permits KeyAlgorithm.Rsa, KeyAlgorithm.Ec {
     record Ec(String curve) implements KeyAlgorithm {
         public Ec {
             Objects.requireNonNull(curve, "curve must not be null");
+            if (curve.isBlank()) {
+                throw new IllegalArgumentException("curve must not be blank");
+            }
         }
 
         @Override

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
@@ -52,7 +52,7 @@ public class QuickPki {
         this.provider = provider;
         this.issuerInfo = info;
         try {
-            issuer = createIssuer(info);
+            issuer = createIssuer();
         } catch (Exception e) {
             throw new QuickPkiException("Failed to build issuer certificate", e);
         }
@@ -83,6 +83,17 @@ public class QuickPki {
         return serial;
     }
 
+    // KeyUsage.keyEncipherment is RSA key-transport semantics; for EC keys it is
+    // meaningless and some strict validators reject it. Use keyAgreement (ECDH)
+    // for EC, matching the convention that Let's Encrypt etc. follow.
+    private KeyUsage leafKeyUsageFor(KeyPair keyPair) {
+        String algo = keyPair.getPublic().getAlgorithm();
+        if ("EC".equalsIgnoreCase(algo)) {
+            return new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyAgreement);
+        }
+        return new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment);
+    }
+
 
     public static QuickPki createDefault() {
         return new QuickPki(ensureBouncyCastleProvider(), IssuerInfo.builder().build());
@@ -105,17 +116,17 @@ public class QuickPki {
         return issuer;
     }
 
-    private CertificateBundle createIssuer(IssuerInfo info) throws Exception {
+    private CertificateBundle createIssuer() throws Exception {
         Date startDate = Date
-                .from(info.getValidFrom());
+                .from(issuerInfo.getValidFrom());
 
         Date endDate = Date
-                .from(info.getValidUntil());
+                .from(issuerInfo.getValidUntil());
 
         KeyPair rootKeyPair = newKeyPair();
         BigInteger rootSerialNum = newSerialNumber();
 
-        SubjectName subjectName = Optional.ofNullable(info.getSubjectName())
+        SubjectName subjectName = Optional.ofNullable(issuerInfo.getSubjectName())
                 .orElse(SubjectName.builder()
                         .commonName("Default Root Issuer")
                         .build());
@@ -186,8 +197,7 @@ public class QuickPki {
 
         JcaX509ExtensionUtils extUtils = new JcaX509ExtensionUtils();
         certificateBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
-        certificateBuilder.addExtension(Extension.keyUsage, true,
-                new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment));
+        certificateBuilder.addExtension(Extension.keyUsage, true, leafKeyUsageFor(keyPair));
         certificateBuilder.addExtension(Extension.extendedKeyUsage, false,
                 new ExtendedKeyUsage(new KeyPurposeId[] {
                         KeyPurposeId.id_kp_serverAuth,

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
@@ -21,13 +21,14 @@ import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 import java.math.BigInteger;
+import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -57,9 +58,18 @@ public class QuickPki {
         }
     }
 
-    private KeyPair newKeyPair() throws NoSuchAlgorithmException {
-        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA", provider);
-        generator.initialize(2048, secureRandom);
+    private KeyPair newKeyPair() throws GeneralSecurityException {
+        KeyAlgorithm algorithm = issuerInfo.getKeyAlgorithm();
+        KeyPairGenerator generator;
+        if (algorithm instanceof KeyAlgorithm.Rsa rsa) {
+            generator = KeyPairGenerator.getInstance("RSA", provider);
+            generator.initialize(rsa.bits(), secureRandom);
+        } else if (algorithm instanceof KeyAlgorithm.Ec ec) {
+            generator = KeyPairGenerator.getInstance("EC", provider);
+            generator.initialize(new ECGenParameterSpec(ec.curve()), secureRandom);
+        } else {
+            throw new IllegalStateException("Unsupported KeyAlgorithm: " + algorithm);
+        }
         return generator.generateKeyPair();
     }
 
@@ -112,7 +122,7 @@ public class QuickPki {
 
         X500Name rootCertIssuer = buildX500Name(subjectName);
         X500Name rootCertSubject = rootCertIssuer;
-        ContentSigner rootCertContentSigner = new JcaContentSignerBuilder("SHA256withRSA")
+        ContentSigner rootCertContentSigner = new JcaContentSignerBuilder(issuerInfo.getEffectiveSignatureAlgorithm())
                 .setProvider(provider).build(rootKeyPair.getPrivate());
         X509v3CertificateBuilder rootCertBuilder =
                 new JcaX509v3CertificateBuilder(rootCertIssuer, rootSerialNum,
@@ -168,7 +178,7 @@ public class QuickPki {
             subjectName = SubjectName.builder().commonName("Default Subject").build();
         }
         X500Name subject = buildX500Name(subjectName);
-        ContentSigner rootCertContentSigner = new JcaContentSignerBuilder("SHA256withRSA")
+        ContentSigner rootCertContentSigner = new JcaContentSignerBuilder(issuerInfo.getEffectiveSignatureAlgorithm())
                 .setProvider(provider).build(this.issuer.getKeyPair().getPrivate());
         X509v3CertificateBuilder certificateBuilder =
                 new JcaX509v3CertificateBuilder(issuerSubject, serialNum,

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
@@ -488,6 +488,10 @@ public class PkiTests {
 
         X509Certificate root = pki.getIssuer().getCertificate();
         assertEquals("RSA", root.getPublicKey().getAlgorithm());
+        java.security.interfaces.RSAPublicKey rsaKey =
+                (java.security.interfaces.RSAPublicKey) root.getPublicKey();
+        assertEquals(2048, rsaKey.getModulus().bitLength(),
+                "default key size must be 2048");
         assertTrue("SHA256withRSA".equalsIgnoreCase(root.getSigAlgName()),
                 "expected SHA256withRSA, got " + root.getSigAlgName());
     }
@@ -554,6 +558,55 @@ public class PkiTests {
                 () -> KeyAlgorithm.rsa(1024));
         assertTrue(ex.getMessage().contains("2048"),
                 "rejection should mention the minimum, got: " + ex.getMessage());
+    }
+
+    // keyEncipherment is RSA key-transport; for EC keys it's meaningless and
+    // some validators reject it. EC leaves should get keyAgreement instead.
+    @Test
+    void ecLeafHasKeyAgreementNotKeyEncipherment() {
+        QuickPki pki = QuickPki.create(IssuerInfo.builder()
+                .keyAlgorithm(KeyAlgorithm.ec("secp256r1"))
+                .build());
+
+        boolean[] keyUsage = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("EC Leaf").build())
+                .build())
+                .getCertificate().getKeyUsage();
+
+        assertNotNull(keyUsage);
+        assertTrue(keyUsage[0], "EC leaf must assert digitalSignature");
+        assertTrue(keyUsage[4], "EC leaf must assert keyAgreement");
+        assertFalse(keyUsage[2], "EC leaf must NOT assert keyEncipherment");
+    }
+
+    @Test
+    void rsaLeafKeepsKeyEncipherment() {
+        QuickPki pki = QuickPki.createDefault();
+
+        boolean[] keyUsage = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("RSA Leaf").build())
+                .build())
+                .getCertificate().getKeyUsage();
+
+        assertTrue(keyUsage[0], "RSA leaf must assert digitalSignature");
+        assertTrue(keyUsage[2], "RSA leaf must assert keyEncipherment");
+        assertFalse(keyUsage[4], "RSA leaf must NOT assert keyAgreement");
+    }
+
+    @Test
+    void blankSignatureAlgorithmIsRejected() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> IssuerInfo.builder().signatureAlgorithm(""));
+        assertTrue(ex.getMessage().contains("signatureAlgorithm"),
+                "rejection should name the parameter, got: " + ex.getMessage());
+    }
+
+    @Test
+    void blankEcCurveIsRejected() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> KeyAlgorithm.ec("   "));
+        assertTrue(ex.getMessage().contains("curve"),
+                "rejection should name the parameter, got: " + ex.getMessage());
     }
 
     @BeforeAll

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
@@ -482,6 +482,80 @@ public class PkiTests {
                 "NPE message must name the rejected parameter, got: " + ex.getMessage());
     }
 
+    @Test
+    void defaultPkiUsesRsa2048AndSha256() {
+        QuickPki pki = QuickPki.createDefault();
+
+        X509Certificate root = pki.getIssuer().getCertificate();
+        assertEquals("RSA", root.getPublicKey().getAlgorithm());
+        assertTrue("SHA256withRSA".equalsIgnoreCase(root.getSigAlgName()),
+                "expected SHA256withRSA, got " + root.getSigAlgName());
+    }
+
+    @Test
+    void canOverrideRsaKeySize() {
+        QuickPki pki = QuickPki.create(IssuerInfo.builder()
+                .keyAlgorithm(KeyAlgorithm.rsa(3072))
+                .build());
+
+        X509Certificate root = pki.getIssuer().getCertificate();
+        java.security.interfaces.RSAPublicKey rsaKey =
+                (java.security.interfaces.RSAPublicKey) root.getPublicKey();
+        assertEquals(3072, rsaKey.getModulus().bitLength());
+
+        CertificateBundle leaf = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Leaf").build())
+                .build());
+        assertTrue(leaf.issuedBy(pki.getIssuer()));
+        assertEquals(3072, ((java.security.interfaces.RSAPublicKey)
+                leaf.getCertificate().getPublicKey()).getModulus().bitLength());
+    }
+
+    @Test
+    void canIssueWithEcKeysAndDefaultEcdsaSignature() {
+        QuickPki pki = QuickPki.create(IssuerInfo.builder()
+                .keyAlgorithm(KeyAlgorithm.ec("secp256r1"))
+                .build());
+
+        X509Certificate root = pki.getIssuer().getCertificate();
+        assertEquals("EC", root.getPublicKey().getAlgorithm());
+        assertEquals("SHA256WITHECDSA", root.getSigAlgName().toUpperCase());
+
+        CertificateBundle leaf = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("EC Leaf").build())
+                .build());
+        assertEquals("EC", leaf.getCertificate().getPublicKey().getAlgorithm());
+        assertTrue(leaf.issuedBy(pki.getIssuer()),
+                "EC-issued leaf must verify against its EC issuer");
+    }
+
+    @Test
+    void canOverrideSignatureAlgorithmIndependently() {
+        QuickPki pki = QuickPki.create(IssuerInfo.builder()
+                .keyAlgorithm(KeyAlgorithm.rsa(2048))
+                .signatureAlgorithm("SHA384withRSA")
+                .build());
+
+        String rootSigAlg = pki.getIssuer().getCertificate().getSigAlgName();
+        assertTrue("SHA384withRSA".equalsIgnoreCase(rootSigAlg),
+                "expected SHA384withRSA, got " + rootSigAlg);
+
+        CertificateBundle leaf = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Leaf").build())
+                .build());
+        String leafSigAlg = leaf.getCertificate().getSigAlgName();
+        assertTrue("SHA384withRSA".equalsIgnoreCase(leafSigAlg),
+                "expected SHA384withRSA, got " + leafSigAlg);
+    }
+
+    @Test
+    void rsaKeyAlgorithmRejectsTooSmallKeySize() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> KeyAlgorithm.rsa(1024));
+        assertTrue(ex.getMessage().contains("2048"),
+                "rejection should mention the minimum, got: " + ex.getMessage());
+    }
+
     @BeforeAll
     static void setup() {
         Security.addProvider(new BouncyCastleProvider());


### PR DESCRIPTION
## Summary
This PR introduces configurable cryptographic algorithm support to QuickPki, allowing users to specify key algorithms (RSA with configurable key sizes, or EC with configurable curves) and signature algorithms independently.

## Key Changes
- **New `KeyAlgorithm` sealed interface**: Provides factory methods and implementations for RSA and EC key algorithms
  - `KeyAlgorithm.rsa(int bits)`: Creates RSA keys with configurable bit length (minimum 2048 bits enforced)
  - `KeyAlgorithm.ec(String curve)`: Creates EC keys with configurable curves (e.g., "secp256r1")
  - Each implementation provides a sensible default signature algorithm (SHA256withRSA for RSA, SHA256withECDSA for EC)

- **Enhanced `IssuerInfo`**: 
  - Added `keyAlgorithm` field with default of RSA 2048
  - Added `signatureAlgorithm` field for explicit override
  - New `getEffectiveSignatureAlgorithm()` method that returns explicit signature algorithm or the default implied by the key algorithm

- **Updated `QuickPki.newKeyPair()`**: 
  - Now uses the configured `KeyAlgorithm` from `IssuerInfo`
  - Supports both RSA (with configurable key sizes) and EC (with configurable curves) key generation
  - Uses pattern matching to handle different algorithm types

- **Updated certificate creation**: Both root and leaf certificate signing now use `getEffectiveSignatureAlgorithm()` instead of hardcoded "SHA256withRSA"

## Notable Implementation Details
- RSA key size validation enforces minimum 2048 bits at construction time
- Signature algorithm can be overridden independently of key algorithm, allowing flexibility (e.g., RSA 2048 with SHA384withRSA)
- Sealed interface design ensures type safety and exhaustive pattern matching
- Comprehensive test coverage validates default behavior, RSA key size override, EC key support, and signature algorithm customization

https://claude.ai/code/session_01GSZQVt9X81JViXkz1Wo43H