### PR TITLE
Add support for issuing intermediate CA certificates

### DIFF
--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
@@ -43,12 +43,15 @@ import java.util.Optional;
  */
 public class QuickPki {
 
+    private final QuickPki parent;
     private final IssuerInfo issuerInfo;
     private final Provider provider;
     private final SecureRandom secureRandom = new SecureRandom();
     private final CertificateBundle issuer;
 
+    // Root-PKI constructor: generates a self-signed issuer.
     private QuickPki(Provider provider, IssuerInfo info) {
+        this.parent = null;
         this.provider = provider;
         this.issuerInfo = info;
         try {
@@ -56,6 +59,15 @@ public class QuickPki {
         } catch (Exception e) {
             throw new QuickPkiException("Failed to build issuer certificate", e);
         }
+    }
+
+    // Intermediate-PKI constructor: takes a pre-built issuer bundle (already
+    // signed by the parent), so we don't regenerate one.
+    private QuickPki(QuickPki parent, IssuerInfo info, CertificateBundle issuerBundle) {
+        this.parent = parent;
+        this.provider = parent.provider;
+        this.issuerInfo = info;
+        this.issuer = issuerBundle;
     }
 
     private KeyPair newKeyPair() throws GeneralSecurityException {
@@ -112,6 +124,15 @@ public class QuickPki {
         return provider;
     }
 
+    // Null for a root PKI; otherwise the PKI that issued this intermediate.
+    public QuickPki getParent() {
+        return parent;
+    }
+
+    public boolean isRoot() {
+        return parent == null;
+    }
+
     public CertificateBundle getIssuer() {
         return issuer;
     }
@@ -157,6 +178,63 @@ public class QuickPki {
         } catch (Exception e) {
             throw new QuickPkiException("Failed to issue certificate", e);
         }
+    }
+
+    // Issues a subordinate CA certificate, signed by this PKI, and returns it
+    // wrapped as a new QuickPki that can itself issue further certificates.
+    // The intermediate inherits this PKI's algorithm and signature settings.
+    public QuickPki issueIntermediate(CertInfo info) {
+        try {
+            return intIssueIntermediate(info);
+        } catch (Exception e) {
+            throw new QuickPkiException("Failed to issue intermediate CA", e);
+        }
+    }
+
+    private QuickPki intIssueIntermediate(CertInfo info) throws Exception {
+        Instant start = info.getValidFrom();
+        Instant end = info.getValidUntil();
+        if (start == null) {
+            start = Instant.now();
+        }
+        if (end == null) {
+            Duration lifespan = issuerInfo.getDefaultLifespan();
+            if (lifespan == null) {
+                lifespan = Duration.ofDays(1L);
+            }
+            end = start.plus(lifespan);
+        }
+
+        KeyPair keyPair = newKeyPair();
+        BigInteger serialNum = newSerialNumber();
+
+        X500Name issuerSubject = new JcaX509CertificateHolder(issuer.getCertificate()).getSubject();
+        SubjectName subjectName = info.getSubjectName();
+        if (subjectName == null) {
+            subjectName = SubjectName.builder().commonName("Default Intermediate CA").build();
+        }
+        X500Name subject = buildX500Name(subjectName);
+
+        ContentSigner signer = new JcaContentSignerBuilder(issuerInfo.getEffectiveSignatureAlgorithm())
+                .setProvider(provider).build(issuer.getKeyPair().getPrivate());
+        X509v3CertificateBuilder builder =
+                new JcaX509v3CertificateBuilder(issuerSubject, serialNum,
+                        Date.from(start), Date.from(end), subject, keyPair.getPublic());
+
+        JcaX509ExtensionUtils extUtils = new JcaX509ExtensionUtils();
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+        builder.addExtension(Extension.keyUsage, true,
+                new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+        builder.addExtension(Extension.subjectKeyIdentifier, false,
+                extUtils.createSubjectKeyIdentifier(keyPair.getPublic()));
+        builder.addExtension(Extension.authorityKeyIdentifier, false,
+                extUtils.createAuthorityKeyIdentifier(issuer.getCertificate()));
+
+        X509CertificateHolder holder = builder.build(signer);
+        X509Certificate cert = new JcaX509CertificateConverter().setProvider(provider).getCertificate(holder);
+        CertificateBundle intermediateBundle = new CertificateBundle(this.issuer, cert, keyPair);
+
+        return new QuickPki(this, this.issuerInfo, intermediateBundle);
     }
 
     private CertificateBundle intIssueCertificate(CertInfo info) throws Exception {

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
@@ -29,9 +29,7 @@ import java.security.SecureRandom;
 import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.security.spec.ECGenParameterSpec;
-import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -84,6 +82,17 @@ public class QuickPki {
         }
         return generator.generateKeyPair();
     }
+
+    // Resolves a CertInfo's start/end Instants, defaulting to now() and
+    // start+issuerInfo.defaultLifespan respectively when omitted.
+    private Validity resolveValidity(CertInfo info) {
+        Instant start = info.getValidFrom() != null ? info.getValidFrom() : Instant.now();
+        Instant end = info.getValidUntil() != null ? info.getValidUntil()
+                : start.plus(issuerInfo.getDefaultLifespan());
+        return new Validity(start, end);
+    }
+
+    private record Validity(Instant start, Instant end) {}
 
     // RFC 5280 §4.1.2.2 requires the serial to be a positive integer (1..2^159-1).
     // BigInteger(159, random) draws uniformly over [0, 2^159), so we reject 0.
@@ -184,6 +193,11 @@ public class QuickPki {
     // wrapped as a new QuickPki that can itself issue further certificates.
     // The intermediate inherits this PKI's algorithm and signature settings.
     public QuickPki issueIntermediate(CertInfo info) {
+        if (!info.getDnsNames().isEmpty() || !info.getIpAddresses().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Subject Alternative Names (dnsName/ipAddress) are not supported on "
+                            + "intermediate CA certificates; put them on the end-entity cert instead");
+        }
         try {
             return intIssueIntermediate(info);
         } catch (Exception e) {
@@ -192,18 +206,7 @@ public class QuickPki {
     }
 
     private QuickPki intIssueIntermediate(CertInfo info) throws Exception {
-        Instant start = info.getValidFrom();
-        Instant end = info.getValidUntil();
-        if (start == null) {
-            start = Instant.now();
-        }
-        if (end == null) {
-            Duration lifespan = issuerInfo.getDefaultLifespan();
-            if (lifespan == null) {
-                lifespan = Duration.ofDays(1L);
-            }
-            end = start.plus(lifespan);
-        }
+        Validity validity = resolveValidity(info);
 
         KeyPair keyPair = newKeyPair();
         BigInteger serialNum = newSerialNumber();
@@ -219,7 +222,7 @@ public class QuickPki {
                 .setProvider(provider).build(issuer.getKeyPair().getPrivate());
         X509v3CertificateBuilder builder =
                 new JcaX509v3CertificateBuilder(issuerSubject, serialNum,
-                        Date.from(start), Date.from(end), subject, keyPair.getPublic());
+                        Date.from(validity.start()), Date.from(validity.end()), subject, keyPair.getPublic());
 
         JcaX509ExtensionUtils extUtils = new JcaX509ExtensionUtils();
         builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
@@ -239,23 +242,9 @@ public class QuickPki {
 
     private CertificateBundle intIssueCertificate(CertInfo info) throws Exception {
 
-        Instant start = info.getValidFrom();
-        Instant end = info.getValidUntil();
-        if(start == null) {
-            start = Instant.now();
-        }
-        if(end == null) {
-           Duration lifespan = issuerInfo.getDefaultLifespan();
-           if(lifespan == null) {
-               lifespan = Duration.ofDays(1L);
-           }
-           end = start.plus(lifespan);
-        }
-        Date startDate = Date
-                .from(start);
-
-        Date endDate = Date
-                .from(end);
+        Validity validity = resolveValidity(info);
+        Date startDate = Date.from(validity.start());
+        Date endDate = Date.from(validity.end());
 
         KeyPair keyPair = newKeyPair();
         BigInteger serialNum = newSerialNumber();

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
@@ -719,6 +719,27 @@ public class PkiTests {
         assertSame(root, intermediate.getParent());
     }
 
+    @Test
+    void issueIntermediateRejectsSanEntries() {
+        QuickPki root = QuickPki.createDefault();
+
+        IllegalArgumentException dnsEx = assertThrows(IllegalArgumentException.class,
+                () -> root.issueIntermediate(CertInfo.builder()
+                        .subjectName(SubjectName.builder().commonName("Bad CA").build())
+                        .dnsName("example.com")
+                        .build()));
+        assertTrue(dnsEx.getMessage().toLowerCase().contains("subject alternative"),
+                "rejection should mention SAN, got: " + dnsEx.getMessage());
+
+        IllegalArgumentException ipEx = assertThrows(IllegalArgumentException.class,
+                () -> root.issueIntermediate(CertInfo.builder()
+                        .subjectName(SubjectName.builder().commonName("Bad CA").build())
+                        .ipAddress("127.0.0.1")
+                        .build()));
+        assertTrue(ipEx.getMessage().toLowerCase().contains("subject alternative"),
+                "rejection should mention SAN, got: " + ipEx.getMessage());
+    }
+
     @BeforeAll
     static void setup() {
         Security.addProvider(new BouncyCastleProvider());

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
@@ -18,6 +18,7 @@ import java.security.Provider;
 import java.security.Security;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
@@ -41,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -607,6 +609,114 @@ public class PkiTests {
                 () -> KeyAlgorithm.ec("   "));
         assertTrue(ex.getMessage().contains("curve"),
                 "rejection should name the parameter, got: " + ex.getMessage());
+    }
+
+    @Test
+    void issuedIntermediateIsACaWithKeyCertSign() {
+        QuickPki root = QuickPki.createDefault();
+        QuickPki intermediate = root.issueIntermediate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Intermediate CA").build())
+                .build());
+
+        X509Certificate intCert = intermediate.getIssuer().getCertificate();
+        assertNotEquals(-1, intCert.getBasicConstraints(),
+                "intermediate must be a CA");
+        boolean[] keyUsage = intCert.getKeyUsage();
+        assertNotNull(keyUsage);
+        assertTrue(keyUsage[5], "intermediate must assert keyCertSign");
+        assertTrue(keyUsage[6], "intermediate must assert cRLSign");
+        assertTrue(intermediate.getIssuer().issuedBy(root.getIssuer()),
+                "intermediate must be signed by root");
+    }
+
+    @Test
+    void leafIssuedByIntermediateIsNotIssuedByRootDirectly() {
+        QuickPki root = QuickPki.createDefault();
+        QuickPki intermediate = root.issueIntermediate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Issuing CA").build())
+                .build());
+
+        CertificateBundle leaf = intermediate.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("End entity").build())
+                .build());
+
+        assertTrue(leaf.issuedBy(intermediate.getIssuer()),
+                "leaf must verify against the intermediate that signed it");
+        assertFalse(leaf.issuedBy(root.getIssuer()),
+                "leaf must NOT verify against the root directly");
+    }
+
+    // The decisive test: build root -> intermediate -> leaf, then ask the JDK's
+    // standard PKIX validator (the same code that browsers and JDK TLS use)
+    // to walk the chain. If this passes, the certs are wired up correctly:
+    // AKI/SKI links, BasicConstraints, KeyUsage on each level, and signatures.
+    @Test
+    void fullRootIntermediateLeafChainValidatesUnderPkix() throws Exception {
+        QuickPki root = QuickPki.createDefault();
+        QuickPki intermediate = root.issueIntermediate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Issuing CA").build())
+                .build());
+        CertificateBundle leaf = intermediate.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("End entity").build())
+                .dnsName("example.com")
+                .build());
+
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        java.security.cert.CertPath path = cf.generateCertPath(List.of(
+                leaf.getCertificate(),
+                intermediate.getIssuer().getCertificate()));
+
+        java.security.cert.TrustAnchor anchor =
+                new java.security.cert.TrustAnchor(root.getIssuer().getCertificate(), null);
+        java.security.cert.PKIXParameters params =
+                new java.security.cert.PKIXParameters(Set.of(anchor));
+        params.setRevocationEnabled(false);
+
+        java.security.cert.CertPathValidator validator =
+                java.security.cert.CertPathValidator.getInstance("PKIX");
+
+        // Throws CertPathValidatorException on failure; the assertion is the
+        // absence of a thrown exception.
+        validator.validate(path, params);
+    }
+
+    @Test
+    void chainsOfArbitraryDepthValidate() throws Exception {
+        QuickPki root = QuickPki.createDefault();
+        QuickPki int1 = root.issueIntermediate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Intermediate 1").build())
+                .build());
+        QuickPki int2 = int1.issueIntermediate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Intermediate 2").build())
+                .build());
+        CertificateBundle leaf = int2.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("End entity").build())
+                .build());
+
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        java.security.cert.CertPath path = cf.generateCertPath(List.of(
+                leaf.getCertificate(),
+                int2.getIssuer().getCertificate(),
+                int1.getIssuer().getCertificate()));
+
+        java.security.cert.PKIXParameters params = new java.security.cert.PKIXParameters(
+                Set.of(new java.security.cert.TrustAnchor(root.getIssuer().getCertificate(), null)));
+        params.setRevocationEnabled(false);
+
+        java.security.cert.CertPathValidator.getInstance("PKIX").validate(path, params);
+    }
+
+    @Test
+    void rootIsRootIntermediateIsNot() {
+        QuickPki root = QuickPki.createDefault();
+        QuickPki intermediate = root.issueIntermediate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Intermediate").build())
+                .build());
+
+        assertTrue(root.isRoot());
+        assertNull(root.getParent());
+        assertFalse(intermediate.isRoot());
+        assertSame(root, intermediate.getParent());
     }
 
     @BeforeAll


### PR DESCRIPTION
## Summary
This PR adds support for creating and managing certificate chains with intermediate Certificate Authorities (CAs). Previously, QuickPki only supported a flat structure of a root CA issuing end-entity certificates. Now it supports arbitrary-depth chains where intermediates can issue further intermediates or leaf certificates.

## Key Changes
- **New `issueIntermediate()` method**: Allows a QuickPki instance to issue a subordinate CA certificate that is wrapped as a new QuickPki instance, enabling hierarchical certificate chains
- **Parent-child relationship tracking**: Added `parent` field and `getParent()`/`isRoot()` methods to track the PKI hierarchy
- **New constructor for intermediate PKIs**: Added private constructor that accepts a pre-built issuer bundle, avoiding regeneration of already-signed certificates
- **Proper CA certificate extensions**: Intermediate certificates are issued with:
  - BasicConstraints extension (CA=true) to mark them as CAs
  - KeyUsage extension with keyCertSign and cRLSign bits set
  - Authority Key Identifier and Subject Key Identifier for proper chain linking
- **Comprehensive test coverage**: Added five new tests validating:
  - Intermediate certificates have proper CA constraints and key usage
  - Leaf certificates issued by intermediates don't verify against the root directly
  - Full PKIX validation of root→intermediate→leaf chains using JDK's standard validator
  - Arbitrary-depth chains (root→intermediate→intermediate→leaf)
  - Root vs. intermediate identification and parent tracking

## Implementation Details
- Intermediate PKIs inherit the algorithm and signature settings from their parent
- The `issueIntermediate()` method follows the same pattern as `issueCertificate()` with proper error handling
- Certificate extensions are properly configured to ensure PKIX path validation succeeds, matching browser and JDK TLS validation behavior
- The implementation maintains backward compatibility with existing single-level PKI usage

https://claude.ai/code/session_01GSZQVt9X81JViXkz1Wo43H