### PR TITLE
Add PEM, KeyStore, and JWK export methods to certificate bundles

### DIFF
--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertificateBundle.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertificateBundle.java
@@ -1,17 +1,34 @@
 package com.elevenware.quickpki;
 
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.util.Base64;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
 
+import java.io.IOException;
+import java.io.StringWriter;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SignatureException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 public class CertificateBundle {
 
@@ -52,6 +69,11 @@ public class CertificateBundle {
         return certificate;
     }
 
+    // The bundle that signed this one. For a self-signed root, returns this.
+    public CertificateBundle getIssuer() {
+        return issuer;
+    }
+
     public String getCommonName() {
         X500Name x500Name = holder.getSubject();
         return x500Name.getRDNs(BCStyle.CN)[0].getFirst().getValue().toString();
@@ -59,5 +81,115 @@ public class CertificateBundle {
 
     public KeyPair getKeyPair() {
         return keyPair;
+    }
+
+    // The certificate chain from this bundle's cert up to and including the
+    // root, leaf-first - the order Java's TLS stack and most other consumers
+    // expect.
+    public List<X509Certificate> getCertificateChain() {
+        List<X509Certificate> chain = new ArrayList<>();
+        CertificateBundle current = this;
+        while (true) {
+            chain.add(current.certificate);
+            if (current.issuer == current) {
+                break;
+            }
+            current = current.issuer;
+        }
+        return List.copyOf(chain);
+    }
+
+    public String toCertificatePem() {
+        return writePem(certificate);
+    }
+
+    // PKCS#8 PEM (BEGIN PRIVATE KEY) - the modern, algorithm-neutral form;
+    // OpenSSL >= 1.1 and modern Java tools expect this rather than the legacy
+    // BEGIN RSA PRIVATE KEY block.
+    public String toPrivateKeyPem() {
+        StringWriter sw = new StringWriter();
+        try (JcaPEMWriter pemWriter = new JcaPEMWriter(sw)) {
+            // null encryptor = unencrypted PKCS#8.
+            pemWriter.writeObject(new JcaPKCS8Generator(keyPair.getPrivate(), null));
+        } catch (IOException e) {
+            throw new QuickPkiException("Failed to write PKCS#8 private key PEM", e);
+        }
+        return sw.toString();
+    }
+
+    // Concatenated PEM of the full chain, leaf-first. Drop-in for nginx /
+    // Tomcat / curl style "fullchain.pem" configurations.
+    public String toCertificateChainPem() {
+        StringWriter sw = new StringWriter();
+        try (JcaPEMWriter pemWriter = new JcaPEMWriter(sw)) {
+            for (X509Certificate cert : getCertificateChain()) {
+                pemWriter.writeObject(cert);
+            }
+        } catch (IOException e) {
+            throw new QuickPkiException("Failed to write chain PEM", e);
+        }
+        return sw.toString();
+    }
+
+    // PKCS12 KeyStore with this bundle's private key + full chain stored under
+    // `alias`. Returned in-memory; callers store(OutputStream, password) to
+    // serialise.
+    public KeyStore toKeyStore(String alias, char[] password) {
+        Objects.requireNonNull(alias, "alias must not be null");
+        Objects.requireNonNull(password, "password must not be null");
+        try {
+            KeyStore ks = KeyStore.getInstance("PKCS12");
+            ks.load(null, null);
+            X509Certificate[] chain = getCertificateChain().toArray(new X509Certificate[0]);
+            ks.setKeyEntry(alias, keyPair.getPrivate(), password, chain);
+            return ks;
+        } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
+            throw new QuickPkiException("Failed to build PKCS12 KeyStore", e);
+        }
+    }
+
+    // The bundle's public key as a JWK, with x5c populated from the full
+    // chain. The private key is not embedded - if you need it, export PEM /
+    // PKCS12 via the dedicated methods.
+    public JWK toJwk() {
+        try {
+            List<Base64> x5c = new ArrayList<>();
+            for (X509Certificate cert : getCertificateChain()) {
+                x5c.add(Base64.encode(cert.getEncoded()));
+            }
+            String publicAlgorithm = certificate.getPublicKey().getAlgorithm();
+            if ("RSA".equalsIgnoreCase(publicAlgorithm)) {
+                return new RSAKey.Builder((RSAPublicKey) certificate.getPublicKey())
+                        .keyUse(KeyUse.SIGNATURE)
+                        .x509CertChain(x5c)
+                        .build();
+            }
+            if ("EC".equalsIgnoreCase(publicAlgorithm)) {
+                ECPublicKey ecKey = (ECPublicKey) certificate.getPublicKey();
+                Curve curve = Curve.forECParameterSpec(ecKey.getParams());
+                if (curve == null) {
+                    throw new QuickPkiException(
+                            "Unsupported EC curve for JWK export: " + ecKey.getParams());
+                }
+                return new ECKey.Builder(curve, ecKey)
+                        .keyUse(KeyUse.SIGNATURE)
+                        .x509CertChain(x5c)
+                        .build();
+            }
+            throw new QuickPkiException(
+                    "Unsupported public key algorithm for JWK export: " + publicAlgorithm);
+        } catch (CertificateEncodingException e) {
+            throw new QuickPkiException("Failed to encode certificate for JWK x5c", e);
+        }
+    }
+
+    private static String writePem(Object jcaObject) {
+        StringWriter sw = new StringWriter();
+        try (JcaPEMWriter pemWriter = new JcaPEMWriter(sw)) {
+            pemWriter.writeObject(jcaObject);
+        } catch (IOException e) {
+            throw new QuickPkiException("Failed to write PEM", e);
+        }
+        return sw.toString();
     }
 }

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertificateBundle.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertificateBundle.java
@@ -32,6 +32,12 @@ import java.util.Objects;
 
 public class CertificateBundle {
 
+    // Hard cap on chain walks. Real PKI chains are 2-5 levels deep; 64 is far
+    // beyond anything legitimate and ensures we fail fast rather than hang if
+    // a caller ever constructs a pathological bundle graph (today the final
+    // issuer field plus Java's evaluation order make cycles unconstructible
+    // through the normal API, but reflection or future API changes could).
+    private static final int MAX_CHAIN_DEPTH = 64;
 
     private final CertificateBundle issuer;
     private final X509Certificate certificate;
@@ -89,14 +95,15 @@ public class CertificateBundle {
     public List<X509Certificate> getCertificateChain() {
         List<X509Certificate> chain = new ArrayList<>();
         CertificateBundle current = this;
-        while (true) {
+        for (int depth = 0; depth < MAX_CHAIN_DEPTH; depth++) {
             chain.add(current.certificate);
             if (current.issuer == current) {
-                break;
+                return List.copyOf(chain);
             }
             current = current.issuer;
         }
-        return List.copyOf(chain);
+        throw new QuickPkiException(
+                "Certificate chain exceeds " + MAX_CHAIN_DEPTH + " levels (possible cycle)");
     }
 
     public String toCertificatePem() {

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
@@ -178,15 +178,18 @@ public class QuickPki {
     public JWKSet toJwkSet() {
         List<JWK> keys = new ArrayList<>();
         CertificateBundle current = issuer;
-        while (true) {
+        for (int depth = 0; depth < MAX_CHAIN_DEPTH; depth++) {
             keys.add(current.toJwk());
             if (current.getIssuer() == current) {
-                break;
+                return new JWKSet(keys);
             }
             current = current.getIssuer();
         }
-        return new JWKSet(keys);
+        throw new QuickPkiException(
+                "Certificate chain exceeds " + MAX_CHAIN_DEPTH + " levels (possible cycle)");
     }
+
+    private static final int MAX_CHAIN_DEPTH = 64;
 
     private CertificateBundle createIssuer() throws Exception {
         Date startDate = Date

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
@@ -20,19 +20,28 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+
+import java.io.IOException;
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.spec.ECGenParameterSpec;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -144,6 +153,39 @@ public class QuickPki {
 
     public CertificateBundle getIssuer() {
         return issuer;
+    }
+
+    // PKCS12 truststore containing the chain's root cert as a
+    // TrustedCertificateEntry under `alias`. Suitable for handing to
+    // SSLContext as a trust source on the client side.
+    public KeyStore toTrustStore(String alias) {
+        Objects.requireNonNull(alias, "alias must not be null");
+        try {
+            KeyStore ts = KeyStore.getInstance("PKCS12");
+            ts.load(null, null);
+            List<X509Certificate> chain = issuer.getCertificateChain();
+            X509Certificate root = chain.get(chain.size() - 1);
+            ts.setCertificateEntry(alias, root);
+            return ts;
+        } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
+            throw new QuickPkiException("Failed to build PKCS12 TrustStore", e);
+        }
+    }
+
+    // JWK Set containing the public key (with x5c) of every cert in the chain
+    // from this PKI's issuer up to the root, leaf-first. Useful for serving as
+    // the JWKS endpoint of a mock OIDC issuer in tests.
+    public JWKSet toJwkSet() {
+        List<JWK> keys = new ArrayList<>();
+        CertificateBundle current = issuer;
+        while (true) {
+            keys.add(current.toJwk());
+            if (current.getIssuer() == current) {
+                break;
+            }
+            current = current.getIssuer();
+        }
+        return new JWKSet(keys);
     }
 
     private CertificateBundle createIssuer() throws Exception {

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
@@ -2,7 +2,6 @@ package com.elevenware.quickpki;
 
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jose.jwk.RSAKey;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
@@ -22,6 +21,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.Provider;
@@ -764,7 +764,7 @@ public class PkiTests {
                 "PEM must have the X.509 header, got: " + pem.substring(0, Math.min(80, pem.length())));
 
         X509Certificate parsed = (X509Certificate) CertificateFactory.getInstance("X.509")
-                .generateCertificate(new ByteArrayInputStream(pem.getBytes()));
+                .generateCertificate(new ByteArrayInputStream(pem.getBytes(StandardCharsets.US_ASCII)));
         assertEquals(leaf.getCertificate(), parsed);
     }
 
@@ -802,7 +802,7 @@ public class PkiTests {
 
         String pem = leaf.toCertificateChainPem();
         Collection<? extends Certificate> parsed = CertificateFactory.getInstance("X.509")
-                .generateCertificates(new ByteArrayInputStream(pem.getBytes()));
+                .generateCertificates(new ByteArrayInputStream(pem.getBytes(StandardCharsets.US_ASCII)));
 
         assertEquals(3, parsed.size(), "chain PEM must contain leaf + intermediate + root");
         List<X509Certificate> asList = new ArrayList<>();

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
@@ -1,5 +1,8 @@
 package com.elevenware.quickpki;
 
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
@@ -9,18 +12,27 @@ import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.StringReader;
 import java.math.BigInteger;
+import java.security.KeyStore;
+import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.Security;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPublicKey;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -738,6 +750,181 @@ public class PkiTests {
                         .build()));
         assertTrue(ipEx.getMessage().toLowerCase().contains("subject alternative"),
                 "rejection should mention SAN, got: " + ipEx.getMessage());
+    }
+
+    @Test
+    void certificatePemRoundTrips() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+        CertificateBundle leaf = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("PEM Leaf").build())
+                .build());
+
+        String pem = leaf.toCertificatePem();
+        assertTrue(pem.startsWith("-----BEGIN CERTIFICATE-----"),
+                "PEM must have the X.509 header, got: " + pem.substring(0, Math.min(80, pem.length())));
+
+        X509Certificate parsed = (X509Certificate) CertificateFactory.getInstance("X.509")
+                .generateCertificate(new ByteArrayInputStream(pem.getBytes()));
+        assertEquals(leaf.getCertificate(), parsed);
+    }
+
+    @Test
+    void privateKeyPemRoundTrips() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+        CertificateBundle leaf = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Key Leaf").build())
+                .build());
+
+        String pem = leaf.toPrivateKeyPem();
+        assertTrue(pem.contains("-----BEGIN PRIVATE KEY-----")
+                        || pem.contains("-----BEGIN RSA PRIVATE KEY-----"),
+                "PEM must declare a private key block, got: " + pem.substring(0, Math.min(80, pem.length())));
+
+        // Parse it back via BC's PEMParser and compare to the original.
+        try (PEMParser parser = new PEMParser(new StringReader(pem))) {
+            Object obj = parser.readObject();
+            PrivateKey roundTripped = new JcaPEMKeyConverter()
+                    .getPrivateKey(((org.bouncycastle.asn1.pkcs.PrivateKeyInfo) obj));
+            assertArrayEquals(leaf.getKeyPair().getPrivate().getEncoded(),
+                    roundTripped.getEncoded());
+        }
+    }
+
+    @Test
+    void chainPemContainsEveryLevelInOrder() throws Exception {
+        QuickPki root = QuickPki.createDefault();
+        QuickPki intermediate = root.issueIntermediate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Chain CA").build())
+                .build());
+        CertificateBundle leaf = intermediate.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Chain Leaf").build())
+                .build());
+
+        String pem = leaf.toCertificateChainPem();
+        Collection<? extends Certificate> parsed = CertificateFactory.getInstance("X.509")
+                .generateCertificates(new ByteArrayInputStream(pem.getBytes()));
+
+        assertEquals(3, parsed.size(), "chain PEM must contain leaf + intermediate + root");
+        List<X509Certificate> asList = new ArrayList<>();
+        for (Certificate c : parsed) {
+            asList.add((X509Certificate) c);
+        }
+        assertEquals(leaf.getCertificate(), asList.get(0), "leaf-first ordering");
+        assertEquals(intermediate.getIssuer().getCertificate(), asList.get(1));
+        assertEquals(root.getIssuer().getCertificate(), asList.get(2));
+    }
+
+    @Test
+    void keyStoreRoundTripsThroughPkcs12Bytes() throws Exception {
+        QuickPki root = QuickPki.createDefault();
+        QuickPki intermediate = root.issueIntermediate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("KS CA").build())
+                .build());
+        CertificateBundle leaf = intermediate.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("KS Leaf").build())
+                .build());
+
+        char[] password = "changeit".toCharArray();
+        KeyStore ks = leaf.toKeyStore("server", password);
+
+        // Serialise to bytes and read back, the way a TLS-using app would.
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ks.store(out, password);
+
+        KeyStore reread = KeyStore.getInstance("PKCS12");
+        reread.load(new ByteArrayInputStream(out.toByteArray()), password);
+
+        assertTrue(reread.containsAlias("server"));
+        assertTrue(reread.isKeyEntry("server"));
+
+        Certificate[] chain = reread.getCertificateChain("server");
+        assertEquals(3, chain.length, "stored chain must include leaf + intermediate + root");
+        assertEquals(leaf.getCertificate(), chain[0]);
+
+        PrivateKey key = (PrivateKey) reread.getKey("server", password);
+        assertArrayEquals(leaf.getKeyPair().getPrivate().getEncoded(), key.getEncoded());
+    }
+
+    @Test
+    void trustStoreContainsRootOnly() throws Exception {
+        QuickPki root = QuickPki.createDefault();
+        QuickPki intermediate = root.issueIntermediate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("TS CA").build())
+                .build());
+
+        KeyStore ts = intermediate.toTrustStore("ca-root");
+
+        assertEquals(1, ts.size(), "truststore must contain exactly the root");
+        assertTrue(ts.isCertificateEntry("ca-root"));
+        assertEquals(root.getIssuer().getCertificate(), ts.getCertificate("ca-root"));
+    }
+
+    @Test
+    void rsaJwkRoundTripsWithFullX5cChain() throws Exception {
+        QuickPki root = QuickPki.createDefault();
+        QuickPki intermediate = root.issueIntermediate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("JWK CA").build())
+                .build());
+        CertificateBundle leaf = intermediate.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("JWK Leaf").build())
+                .build());
+
+        JWK jwk = leaf.toJwk();
+
+        // Round-trip through the JWK's JSON representation.
+        JWK parsed = JWK.parse(jwk.toJSONString());
+        assertEquals("RSA", parsed.getKeyType().getValue());
+        assertNull(parsed.toRSAKey().getPrivateExponent(),
+                "exported JWK must NOT include the private key");
+        assertEquals(((RSAPublicKey) leaf.getCertificate().getPublicKey()).getModulus(),
+                parsed.toRSAKey().toRSAPublicKey().getModulus());
+        assertEquals(3, parsed.getX509CertChain().size(),
+                "x5c must include leaf + intermediate + root");
+    }
+
+    @Test
+    void ecJwkExportsAsEcKeyType() {
+        QuickPki pki = QuickPki.create(IssuerInfo.builder()
+                .keyAlgorithm(KeyAlgorithm.ec("secp256r1"))
+                .build());
+        CertificateBundle leaf = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("EC JWK Leaf").build())
+                .build());
+
+        JWK jwk = leaf.toJwk();
+        assertEquals("EC", jwk.getKeyType().getValue());
+        assertEquals("P-256", jwk.toECKey().getCurve().getName());
+        assertNull(jwk.toECKey().getD(), "exported JWK must NOT include the private key");
+    }
+
+    @Test
+    void jwkSetCoversTheFullChain() {
+        QuickPki root = QuickPki.createDefault();
+        QuickPki int1 = root.issueIntermediate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Set CA 1").build())
+                .build());
+        QuickPki int2 = int1.issueIntermediate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Set CA 2").build())
+                .build());
+
+        JWKSet set = int2.toJwkSet();
+        assertEquals(3, set.getKeys().size(),
+                "JWK Set must include int2 + int1 + root, leaf-first");
+    }
+
+    @Test
+    void exportMethodsRejectNullArguments() {
+        QuickPki pki = QuickPki.createDefault();
+        CertificateBundle leaf = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Null Test").build())
+                .build());
+
+        assertThrows(NullPointerException.class,
+                () -> leaf.toKeyStore(null, "changeit".toCharArray()));
+        assertThrows(NullPointerException.class,
+                () -> leaf.toKeyStore("alias", null));
+        assertThrows(NullPointerException.class,
+                () -> pki.toTrustStore(null));
     }
 
     @BeforeAll


### PR DESCRIPTION
## Summary
This PR adds comprehensive export functionality to QuickPki's certificate bundles, enabling users to export certificates and keys in industry-standard formats (PEM, PKCS12 KeyStore, and JWK) for use with TLS servers, clients, and OIDC/JWT systems.

## Key Changes

- **PEM Export Methods** (`CertificateBundle`):
  - `toCertificatePem()` - Export single certificate in X.509 PEM format
  - `toPrivateKeyPem()` - Export private key in PKCS#8 PEM format (unencrypted)
  - `toCertificateChainPem()` - Export full certificate chain (leaf-first) as concatenated PEM

- **KeyStore Export Methods**:
  - `CertificateBundle.toKeyStore(alias, password)` - Create PKCS12 KeyStore with private key and full chain
  - `QuickPki.toTrustStore(alias)` - Create PKCS12 TrustStore containing only the root certificate

- **JWK Export Methods**:
  - `CertificateBundle.toJwk()` - Export public key as JWK with x5c chain (supports RSA and EC keys)
  - `QuickPki.toJwkSet()` - Export full chain as JWK Set (leaf-first ordering)

- **Supporting Changes**:
  - Added `CertificateBundle.getIssuer()` to access the issuing certificate bundle
  - Added `CertificateBundle.getCertificateChain()` to retrieve the full chain in leaf-first order
  - All export methods validate null arguments and throw `NullPointerException` as appropriate
  - Added comprehensive test coverage for all export formats and round-trip scenarios

## Implementation Details

- PEM export uses BouncyCastle's `JcaPEMWriter` for consistent formatting
- PKCS#8 private key export uses `JcaPKCS8Generator` for algorithm-neutral format (preferred over legacy RSA-specific format)
- KeyStore operations use standard Java `KeyStore` API with PKCS12 format for broad compatibility
- JWK export leverages Nimbus JOSE+JWT library with proper x5c chain population
- EC curve detection uses Nimbus's `Curve.forECParameterSpec()` for JWK compatibility
- All export methods follow consistent error handling with `QuickPkiException` wrapping

https://claude.ai/code/session_01GSZQVt9X81JViXkz1Wo43H