### PR TITLE
Allow callers to override default KeyUsage and ExtendedKeyUsage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- We deliberately don't write public Javadoc on every
+                         builder method; the bean-style names are
+                         self-documenting. Suppress the noisy 'no comment'
+                         warnings from the standard doclint checks. -->
+                    <doclint>none</doclint>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -102,11 +102,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <!-- We deliberately don't write public Javadoc on every
-                         builder method; the bean-style names are
-                         self-documenting. Suppress the noisy 'no comment'
-                         warnings from the standard doclint checks. -->
-                    <doclint>none</doclint>
+                    <!-- Silence the noisy 'no comment' warnings on
+                         self-documenting builder methods, but keep the
+                         other doclint groups (HTML, syntax, references)
+                         active so real Javadoc problems still surface. -->
+                    <doclint>all,-missing</doclint>
                 </configuration>
                 <executions>
                     <execution>

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertInfo.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertInfo.java
@@ -147,9 +147,19 @@ public final class CertInfo {
 
         // Add a KeyUsage bit. Calling this any number of times overrides the
         // algorithm-aware default that QuickPki would otherwise pick. Unset
-        // (no calls) means use the default.
+        // (no calls) means use the default. CA-only bits (keyCertSign,
+        // cRLSign) are rejected here: CertInfo describes leaves, and the
+        // resulting cert would have BasicConstraints(false) - which combined
+        // with those bits is RFC 5280-invalid and rejected by PKIX
+        // validators. Intermediates don't go through this path; they get
+        // keyCertSign|cRLSign emitted directly by issueIntermediate.
         public Builder keyUsage(KeyUsageBit bit) {
             Objects.requireNonNull(bit, "keyUsage bit must not be null");
+            if (bit == KeyUsageBit.KEY_CERT_SIGN || bit == KeyUsageBit.CRL_SIGN) {
+                throw new IllegalArgumentException(
+                        bit + " is a CA-only KeyUsage bit; it cannot appear on a leaf "
+                                + "certificate. Use issueIntermediate(...) for CA certs.");
+            }
             if (this.keyUsages == null) {
                 this.keyUsages = EnumSet.noneOf(KeyUsageBit.class);
             }

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertInfo.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertInfo.java
@@ -2,8 +2,11 @@ package com.elevenware.quickpki;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public final class CertInfo {
 
@@ -12,6 +15,8 @@ public final class CertInfo {
     private final Instant validUntil;
     private final List<String> dnsNames;
     private final List<String> ipAddresses;
+    private final Set<KeyUsageBit> keyUsages;
+    private final Set<ExtendedKeyUsageId> extendedKeyUsages;
 
     private CertInfo(Builder builder) {
         this.subjectName = builder.subjectName;
@@ -19,6 +24,13 @@ public final class CertInfo {
         this.validUntil = builder.validUntil;
         this.dnsNames = List.copyOf(builder.dnsNames);
         this.ipAddresses = List.copyOf(builder.ipAddresses);
+        // null vs non-null distinguishes 'use the algorithm-aware default'
+        // from 'use exactly these'. Defensive copy; immutable view returned
+        // from the getter.
+        this.keyUsages = builder.keyUsages == null ? null
+                : Collections.unmodifiableSet(EnumSet.copyOf(builder.keyUsages));
+        this.extendedKeyUsages = builder.extendedKeyUsages == null ? null
+                : Collections.unmodifiableSet(EnumSet.copyOf(builder.extendedKeyUsages));
         // Eager guard for the case where the caller set both fields. The
         // late case (one defaulted from IssuerInfo) is caught at issue time.
         if (this.validFrom != null && this.validUntil != null
@@ -53,6 +65,17 @@ public final class CertInfo {
         return ipAddresses;
     }
 
+    // Null when the caller hasn't expressed a preference (QuickPki picks an
+    // algorithm-aware default). Non-null when the caller specified an explicit
+    // override via Builder.keyUsage(...).
+    public Set<KeyUsageBit> getKeyUsages() {
+        return keyUsages;
+    }
+
+    public Set<ExtendedKeyUsageId> getExtendedKeyUsages() {
+        return extendedKeyUsages;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -61,12 +84,15 @@ public final class CertInfo {
                 && Objects.equals(validFrom, that.validFrom)
                 && Objects.equals(validUntil, that.validUntil)
                 && Objects.equals(dnsNames, that.dnsNames)
-                && Objects.equals(ipAddresses, that.ipAddresses);
+                && Objects.equals(ipAddresses, that.ipAddresses)
+                && Objects.equals(keyUsages, that.keyUsages)
+                && Objects.equals(extendedKeyUsages, that.extendedKeyUsages);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(subjectName, validFrom, validUntil, dnsNames, ipAddresses);
+        return Objects.hash(subjectName, validFrom, validUntil, dnsNames,
+                ipAddresses, keyUsages, extendedKeyUsages);
     }
 
     @Override
@@ -77,6 +103,8 @@ public final class CertInfo {
                 + ", validUntil=" + validUntil
                 + ", dnsNames=" + dnsNames
                 + ", ipAddresses=" + ipAddresses
+                + ", keyUsages=" + keyUsages
+                + ", extendedKeyUsages=" + extendedKeyUsages
                 + '}';
     }
 
@@ -86,6 +114,8 @@ public final class CertInfo {
         private Instant validUntil;
         private final List<String> dnsNames = new ArrayList<>();
         private final List<String> ipAddresses = new ArrayList<>();
+        private EnumSet<KeyUsageBit> keyUsages;
+        private EnumSet<ExtendedKeyUsageId> extendedKeyUsages;
 
         private Builder() {
         }
@@ -112,6 +142,29 @@ public final class CertInfo {
 
         public Builder ipAddress(String ipAddress) {
             this.ipAddresses.add(Objects.requireNonNull(ipAddress, "ipAddress must not be null"));
+            return this;
+        }
+
+        // Add a KeyUsage bit. Calling this any number of times overrides the
+        // algorithm-aware default that QuickPki would otherwise pick. Unset
+        // (no calls) means use the default.
+        public Builder keyUsage(KeyUsageBit bit) {
+            Objects.requireNonNull(bit, "keyUsage bit must not be null");
+            if (this.keyUsages == null) {
+                this.keyUsages = EnumSet.noneOf(KeyUsageBit.class);
+            }
+            this.keyUsages.add(bit);
+            return this;
+        }
+
+        // Add an ExtendedKeyUsage purpose. Same override semantics as
+        // keyUsage(...) - default is serverAuth + clientAuth on leaves.
+        public Builder extendedKeyUsage(ExtendedKeyUsageId id) {
+            Objects.requireNonNull(id, "extendedKeyUsage id must not be null");
+            if (this.extendedKeyUsages == null) {
+                this.extendedKeyUsages = EnumSet.noneOf(ExtendedKeyUsageId.class);
+            }
+            this.extendedKeyUsages.add(id);
             return this;
         }
 

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/ExtendedKeyUsageId.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/ExtendedKeyUsageId.java
@@ -1,0 +1,26 @@
+package com.elevenware.quickpki;
+
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+
+// The six standard ExtendedKeyUsage purposes from RFC 5280 §4.2.1.12. Pass
+// these to CertInfo.Builder.extendedKeyUsage(...) to override the default
+// leaf EKU (serverAuth + clientAuth).
+public enum ExtendedKeyUsageId {
+
+    SERVER_AUTH(KeyPurposeId.id_kp_serverAuth),
+    CLIENT_AUTH(KeyPurposeId.id_kp_clientAuth),
+    CODE_SIGNING(KeyPurposeId.id_kp_codeSigning),
+    EMAIL_PROTECTION(KeyPurposeId.id_kp_emailProtection),
+    TIME_STAMPING(KeyPurposeId.id_kp_timeStamping),
+    OCSP_SIGNING(KeyPurposeId.id_kp_OCSPSigning);
+
+    private final KeyPurposeId keyPurposeId;
+
+    ExtendedKeyUsageId(KeyPurposeId keyPurposeId) {
+        this.keyPurposeId = keyPurposeId;
+    }
+
+    KeyPurposeId keyPurposeId() {
+        return keyPurposeId;
+    }
+}

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/KeyUsageBit.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/KeyUsageBit.java
@@ -1,0 +1,29 @@
+package com.elevenware.quickpki;
+
+import org.bouncycastle.asn1.x509.KeyUsage;
+
+// The nine standard X.509 KeyUsage bits (RFC 5280 §4.2.1.3). Pass these to
+// CertInfo.Builder.keyUsage(...) to override the default leaf KeyUsage that
+// QuickPki picks based on the leaf's key algorithm.
+public enum KeyUsageBit {
+
+    DIGITAL_SIGNATURE(KeyUsage.digitalSignature),
+    NON_REPUDIATION(KeyUsage.nonRepudiation),
+    KEY_ENCIPHERMENT(KeyUsage.keyEncipherment),
+    DATA_ENCIPHERMENT(KeyUsage.dataEncipherment),
+    KEY_AGREEMENT(KeyUsage.keyAgreement),
+    KEY_CERT_SIGN(KeyUsage.keyCertSign),
+    CRL_SIGN(KeyUsage.cRLSign),
+    ENCIPHER_ONLY(KeyUsage.encipherOnly),
+    DECIPHER_ONLY(KeyUsage.decipherOnly);
+
+    private final int bit;
+
+    KeyUsageBit(int bit) {
+        this.bit = bit;
+    }
+
+    int bit() {
+        return bit;
+    }
+}

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
@@ -120,15 +120,40 @@ public class QuickPki {
         return serial;
     }
 
-    // KeyUsage.keyEncipherment is RSA key-transport semantics; for EC keys it is
-    // meaningless and some strict validators reject it. Use keyAgreement (ECDH)
-    // for EC, matching the convention that Let's Encrypt etc. follow.
-    private KeyUsage leafKeyUsageFor(KeyPair keyPair) {
+    // If the caller specified explicit KeyUsage bits on the CertInfo, OR them
+    // together. Otherwise default by key algorithm: RSA gets
+    // digitalSignature|keyEncipherment; EC gets digitalSignature|keyAgreement
+    // because keyEncipherment is RSA key-transport semantics and some strict
+    // validators reject it on EC certs.
+    private KeyUsage leafKeyUsageFor(KeyPair keyPair, CertInfo info) {
+        if (info.getKeyUsages() != null) {
+            int bits = 0;
+            for (KeyUsageBit b : info.getKeyUsages()) {
+                bits |= b.bit();
+            }
+            return new KeyUsage(bits);
+        }
         String algo = keyPair.getPublic().getAlgorithm();
         if ("EC".equalsIgnoreCase(algo)) {
             return new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyAgreement);
         }
         return new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment);
+    }
+
+    // If the caller specified explicit ExtendedKeyUsage purposes, use those
+    // verbatim. Otherwise default to serverAuth + clientAuth, the right shape
+    // for both server and client TLS scenarios.
+    private ExtendedKeyUsage leafEkuFor(CertInfo info) {
+        if (info.getExtendedKeyUsages() != null) {
+            KeyPurposeId[] purposes = info.getExtendedKeyUsages().stream()
+                    .map(ExtendedKeyUsageId::keyPurposeId)
+                    .toArray(KeyPurposeId[]::new);
+            return new ExtendedKeyUsage(purposes);
+        }
+        return new ExtendedKeyUsage(new KeyPurposeId[] {
+                KeyPurposeId.id_kp_serverAuth,
+                KeyPurposeId.id_kp_clientAuth
+        });
     }
 
 
@@ -323,12 +348,8 @@ public class QuickPki {
 
         JcaX509ExtensionUtils extUtils = new JcaX509ExtensionUtils();
         certificateBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
-        certificateBuilder.addExtension(Extension.keyUsage, true, leafKeyUsageFor(keyPair));
-        certificateBuilder.addExtension(Extension.extendedKeyUsage, false,
-                new ExtendedKeyUsage(new KeyPurposeId[] {
-                        KeyPurposeId.id_kp_serverAuth,
-                        KeyPurposeId.id_kp_clientAuth
-                }));
+        certificateBuilder.addExtension(Extension.keyUsage, true, leafKeyUsageFor(keyPair, info));
+        certificateBuilder.addExtension(Extension.extendedKeyUsage, false, leafEkuFor(info));
         certificateBuilder.addExtension(Extension.subjectKeyIdentifier, false,
                 extUtils.createSubjectKeyIdentifier(keyPair.getPublic()));
         certificateBuilder.addExtension(Extension.authorityKeyIdentifier, false,

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
@@ -1039,12 +1039,13 @@ public class PkiTests {
                 .build());
 
         boolean[] keyUsage = bundle.getCertificate().getKeyUsage();
+        assertNotNull(keyUsage, "default leaf must have a KeyUsage extension");
         assertTrue(keyUsage[0], "default RSA leaf must have digitalSignature");
         assertTrue(keyUsage[2], "default RSA leaf must have keyEncipherment");
     }
 
     @Test
-    void multipleKeyUsageBitsCanBeOred() {
+    void multipleKeyUsageBitsCanBeCombined() {
         QuickPki pki = QuickPki.createDefault();
 
         CertificateBundle bundle = pki.issueCertificate(CertInfo.builder()
@@ -1055,6 +1056,7 @@ public class PkiTests {
                 .build());
 
         boolean[] keyUsage = bundle.getCertificate().getKeyUsage();
+        assertNotNull(keyUsage, "leaf must have a KeyUsage extension");
         assertTrue(keyUsage[0], "digitalSignature");
         assertTrue(keyUsage[1], "nonRepudiation");
         assertTrue(keyUsage[3], "dataEncipherment");
@@ -1067,6 +1069,21 @@ public class PkiTests {
                 () -> CertInfo.builder().keyUsage(null));
         assertThrows(NullPointerException.class,
                 () -> CertInfo.builder().extendedKeyUsage(null));
+    }
+
+    @Test
+    void caOnlyKeyUsageBitsAreRejectedOnLeafCertInfo() {
+        // keyCertSign + BasicConstraints(false) is RFC 5280-invalid and PKIX
+        // validators reject it. CertInfo is leaf metadata; reject CA-only
+        // bits at the builder boundary to fail fast with a clear message
+        // rather than producing a silently-broken cert.
+        IllegalArgumentException certSignEx = assertThrows(IllegalArgumentException.class,
+                () -> CertInfo.builder().keyUsage(KeyUsageBit.KEY_CERT_SIGN));
+        assertTrue(certSignEx.getMessage().contains("CA-only"),
+                "rejection should explain why, got: " + certSignEx.getMessage());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> CertInfo.builder().keyUsage(KeyUsageBit.CRL_SIGN));
     }
 
     @BeforeAll

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
@@ -996,6 +996,79 @@ public class PkiTests {
                 "message should mention validFrom, got: " + ex.getMessage());
     }
 
+    @Test
+    void leafKeyUsageHonoursCallerOverride() {
+        QuickPki pki = QuickPki.createDefault();
+
+        // Code-signing certs typically only need digitalSignature; explicitly
+        // omit keyEncipherment to override the RSA default.
+        CertificateBundle bundle = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Code Signer").build())
+                .keyUsage(KeyUsageBit.DIGITAL_SIGNATURE)
+                .build());
+
+        boolean[] keyUsage = bundle.getCertificate().getKeyUsage();
+        assertNotNull(keyUsage);
+        assertTrue(keyUsage[0], "explicitly-set digitalSignature must be present");
+        assertFalse(keyUsage[2], "default keyEncipherment must NOT be added when override set");
+    }
+
+    @Test
+    void leafEkuHonoursCallerOverride() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+
+        CertificateBundle bundle = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Code Signer").build())
+                .extendedKeyUsage(ExtendedKeyUsageId.CODE_SIGNING)
+                .build());
+
+        List<String> eku = bundle.getCertificate().getExtendedKeyUsage();
+        assertNotNull(eku);
+        assertEquals(1, eku.size(), "only the explicitly-set EKU should be present");
+        assertEquals(KeyPurposeId.id_kp_codeSigning.getId(), eku.get(0));
+    }
+
+    @Test
+    void leafKeyUsageDefaultStillAppliesWhenOverrideUnset() {
+        QuickPki pki = QuickPki.createDefault();
+
+        // No keyUsage / extendedKeyUsage set on CertInfo - defaults must still
+        // apply (RSA leaf gets digitalSignature + keyEncipherment).
+        CertificateBundle bundle = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Default").build())
+                .build());
+
+        boolean[] keyUsage = bundle.getCertificate().getKeyUsage();
+        assertTrue(keyUsage[0], "default RSA leaf must have digitalSignature");
+        assertTrue(keyUsage[2], "default RSA leaf must have keyEncipherment");
+    }
+
+    @Test
+    void multipleKeyUsageBitsCanBeOred() {
+        QuickPki pki = QuickPki.createDefault();
+
+        CertificateBundle bundle = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Multi").build())
+                .keyUsage(KeyUsageBit.DIGITAL_SIGNATURE)
+                .keyUsage(KeyUsageBit.NON_REPUDIATION)
+                .keyUsage(KeyUsageBit.DATA_ENCIPHERMENT)
+                .build());
+
+        boolean[] keyUsage = bundle.getCertificate().getKeyUsage();
+        assertTrue(keyUsage[0], "digitalSignature");
+        assertTrue(keyUsage[1], "nonRepudiation");
+        assertTrue(keyUsage[3], "dataEncipherment");
+        assertFalse(keyUsage[2], "keyEncipherment NOT in override set");
+    }
+
+    @Test
+    void keyUsageBuilderRejectsNull() {
+        assertThrows(NullPointerException.class,
+                () -> CertInfo.builder().keyUsage(null));
+        assertThrows(NullPointerException.class,
+                () -> CertInfo.builder().extendedKeyUsage(null));
+    }
+
     @BeforeAll
     static void setup() {
         Security.addProvider(new BouncyCastleProvider());


### PR DESCRIPTION
## Summary
This PR adds support for callers to explicitly specify KeyUsage and ExtendedKeyUsage extensions when issuing leaf certificates, overriding QuickPki's algorithm-aware defaults.

## Key Changes
- **New enums**: `KeyUsageBit` and `ExtendedKeyUsageId` provide type-safe access to the standard X.509 key usage and extended key usage purposes
- **CertInfo.Builder enhancements**: Added `keyUsage(KeyUsageBit)` and `extendedKeyUsage(ExtendedKeyUsageId)` methods that can be called multiple times to build up a set of desired extensions
- **Smart defaults preserved**: When these builder methods are not called, QuickPki continues to apply algorithm-aware defaults (RSA gets digitalSignature|keyEncipherment; EC gets digitalSignature|keyAgreement)
- **Null-based override detection**: The implementation uses null vs. non-null to distinguish between "use the default" and "use exactly these values"
- **Comprehensive test coverage**: Five new tests verify override behavior, default application, multiple bits, and null rejection

## Implementation Details
- Both `keyUsage()` and `extendedKeyUsage()` builder methods use `Objects.requireNonNull()` to reject null arguments
- `CertInfo` stores the sets as immutable views (via `Collections.unmodifiableSet()`) after defensive copying
- The `leafKeyUsageFor()` and new `leafEkuFor()` methods in `QuickPki` check for caller-specified values before applying defaults
- Updated `equals()`, `hashCode()`, and `toString()` in `CertInfo` to include the new fields
- Suppressed javadoc doclint warnings in pom.xml since builder methods are self-documenting

https://claude.ai/code/session_01GSZQVt9X81JViXkz1Wo43H