### PR TITLE
Build and publish multi-arch Docker images

### DIFF
--- a/.github/workflows/publishImages.yml
+++ b/.github/workflows/publishImages.yml
@@ -1,0 +1,58 @@
+name: Build and publish Docker images
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: quick-pki-acme-server
+            dockerfile: quick-pki-acme-server/Dockerfile
+          - name: quick-pki-admin
+            dockerfile: quick-pki-admin/Dockerfile
+    steps:
+      - name: Checkout project sources
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}
+          tags: |
+            type=raw,value=latest
+            type=sha,format=long
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}


### PR DESCRIPTION
## Summary
Adds `.github/workflows/publishImages.yml` to build the ACME server and admin UI Docker images and publish them to GitHub Packages on every merge to `main`.

- Multi-arch builds: `linux/amd64` and `linux/arm64` (QEMU + Buildx)
- Matrix job covering `quick-pki-acme-server` and `quick-pki-admin`
- Pushes to `ghcr.io/<owner>/<image>`, tagged `latest` and the full commit SHA
- Authenticates with the built-in `GITHUB_TOKEN` (`packages: write`) — no extra secrets needed
- GitHub Actions build cache per image

## Notes
- Build context is the repo root, since both Dockerfiles `COPY` paths like `pom.xml`, `quick-pki-lib/`, and `quick-pki-admin/`.
- First-run packages are created private and linked to the owner; visibility/repo-linking can be adjusted once in the Packages UI.
- The existing `buildAndPublish.yml` (Java library) is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)