### PR TITLE
Mint certificates directly from PKCS#10 CSRs

### DIFF
--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/CertificateAuthorityService.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/CertificateAuthorityService.java
@@ -66,31 +66,44 @@ final class CertificateAuthorityService {
         try {
             PKCS10CertificationRequest csr = new PKCS10CertificationRequest(csrDer);
 
-            List<String> csrNames = Csr.subjectAlternativeNames(csr);
-            Set<String> allowed = new HashSet<>(validatedIdentifiers.stream().map(Identifier::value).toList());
-            List<String> names = csrNames.stream()
-                    .filter(allowed::contains)
-                    .distinct()
-                    .toList();
-            if (names.isEmpty()) {
-                throw new AcmeException(400, "badCSR", "CSR must contain at least one validated subjectAltName");
+            // Filter per-type: a validated "dns:example.com" identifier
+            // authorises a dNSName SAN, not an iPAddress SAN of the same
+            // string. Carrying the tag through avoids issuing a cert whose
+            // SAN type disagrees with what was actually validated.
+            Set<String> allowedDns = identifierValuesOfType(validatedIdentifiers, "dns");
+            Set<String> allowedIp = identifierValuesOfType(validatedIdentifiers, "ip");
+
+            List<String> csrDnsNames = Csr.dnsSubjectAlternativeNames(csr);
+            List<String> csrIpNames = Csr.ipSubjectAlternativeNames(csr);
+
+            if (!csrDnsNames.stream().allMatch(allowedDns::contains)
+                    || !csrIpNames.stream().allMatch(allowedIp::contains)) {
+                throw new AcmeException(400, "badCSR",
+                        "CSR contains subjectAltName entries that were not validated");
             }
-            if (names.size() != csrNames.stream().distinct().count()) {
-                throw new AcmeException(400, "badCSR", "CSR contains subjectAltName entries that were not validated");
+
+            List<String> dnsNames = csrDnsNames.stream().distinct().toList();
+            List<String> ipNames = csrIpNames.stream().distinct().toList();
+            if (dnsNames.isEmpty() && ipNames.isEmpty()) {
+                throw new AcmeException(400, "badCSR",
+                        "CSR must contain at least one validated subjectAltName");
             }
+
+            // CN is just a label - take the first SAN in CSR source order so
+            // it stays stable across re-issuance.
+            String commonName = Csr.subjectAlternativeNames(csr).get(0);
 
             Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
             CertInfo.Builder cert = CertInfo.builder()
-                    .subjectName(SubjectName.builder().commonName(names.get(0)).build())
+                    .subjectName(SubjectName.builder().commonName(commonName).build())
                     .validFrom(now.minus(5, ChronoUnit.MINUTES))
                     .validUntil(now.plus(config.certificateLifetime()))
                     .extendedKeyUsage(ExtendedKeyUsageId.SERVER_AUTH);
-            for (String name : names) {
-                if (Csr.isIpAddress(name)) {
-                    cert.ipAddress(name);
-                } else {
-                    cert.dnsName(name);
-                }
+            for (String dns : dnsNames) {
+                cert.dnsName(dns);
+            }
+            for (String ip : ipNames) {
+                cert.ipAddress(ip);
             }
             CertificateBundle bundle = pki.issueCertificate(csr, cert.build());
             return new IssuedCertificate(bundle.toCertificatePem(), bundle.toCertificateChainPem());
@@ -99,6 +112,13 @@ final class CertificateAuthorityService {
         } catch (Exception e) {
             throw new AcmeException(400, "badCSR", "Failed to issue certificate from CSR: " + e.getMessage());
         }
+    }
+
+    private static Set<String> identifierValuesOfType(List<Identifier> identifiers, String type) {
+        return identifiers.stream()
+                .filter(id -> type.equalsIgnoreCase(id.type()))
+                .map(Identifier::value)
+                .collect(java.util.stream.Collectors.toCollection(HashSet::new));
     }
 
     private static CertificateAuthorityService load(

--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/CertificateAuthorityService.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/CertificateAuthorityService.java
@@ -2,27 +2,20 @@ package com.elevenware.quickpki.acme;
 
 import com.elevenware.quickpki.CertInfo;
 import com.elevenware.quickpki.CertificateBundle;
+import com.elevenware.quickpki.Csr;
 import com.elevenware.quickpki.ExtendedKeyUsageId;
 import com.elevenware.quickpki.IssuerInfo;
 import com.elevenware.quickpki.QuickPki;
 import com.elevenware.quickpki.SubjectName;
-import org.bouncycastle.asn1.ASN1OctetString;
-import org.bouncycastle.asn1.x509.Extension;
-import org.bouncycastle.asn1.x509.Extensions;
-import org.bouncycastle.asn1.x509.GeneralName;
-import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
-import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
-import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
-import java.net.InetAddress;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.PrivateKey;
@@ -30,7 +23,6 @@ import java.security.Security;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
@@ -73,15 +65,8 @@ final class CertificateAuthorityService {
     IssuedCertificate issue(byte[] csrDer, List<Identifier> validatedIdentifiers) {
         try {
             PKCS10CertificationRequest csr = new PKCS10CertificationRequest(csrDer);
-            if (!csr.isSignatureValid(new JcaContentVerifierProviderBuilder()
-                    .setProvider(BouncyCastleProvider.PROVIDER_NAME)
-                    .build(csr.getSubjectPublicKeyInfo()))) {
-                throw new AcmeException(400, "badCSR", "CSR signature is invalid");
-            }
 
-            JcaPKCS10CertificationRequest jcaCsr = new JcaPKCS10CertificationRequest(csr)
-                    .setProvider(BouncyCastleProvider.PROVIDER_NAME);
-            List<String> csrNames = csrSubjectAlternativeNames(csr);
+            List<String> csrNames = Csr.subjectAlternativeNames(csr);
             Set<String> allowed = new HashSet<>(validatedIdentifiers.stream().map(Identifier::value).toList());
             List<String> names = csrNames.stream()
                     .filter(allowed::contains)
@@ -101,13 +86,13 @@ final class CertificateAuthorityService {
                     .validUntil(now.plus(config.certificateLifetime()))
                     .extendedKeyUsage(ExtendedKeyUsageId.SERVER_AUTH);
             for (String name : names) {
-                if (isIpAddress(name)) {
+                if (Csr.isIpAddress(name)) {
                     cert.ipAddress(name);
                 } else {
                     cert.dnsName(name);
                 }
             }
-            CertificateBundle bundle = pki.issueCertificate(cert.build(), jcaCsr.getPublicKey());
+            CertificateBundle bundle = pki.issueCertificate(csr, cert.build());
             return new IssuedCertificate(bundle.toCertificatePem(), bundle.toCertificateChainPem());
         } catch (AcmeException e) {
             throw e;
@@ -171,42 +156,6 @@ final class CertificateAuthorityService {
                 .validUntil(now.plus(3650, ChronoUnit.DAYS))
                 .defaultLifespan(config.certificateLifetime())
                 .build();
-    }
-
-    private static List<String> csrSubjectAlternativeNames(PKCS10CertificationRequest csr) throws Exception {
-        Extensions extensions = csr.getRequestedExtensions();
-        if (extensions == null) {
-            return List.of();
-        }
-        GeneralNames generalNames = GeneralNames.fromExtensions(extensions, Extension.subjectAlternativeName);
-        if (generalNames == null) {
-            return List.of();
-        }
-        return List.of(generalNames.getNames()).stream()
-                .filter(name -> name.getTagNo() == GeneralName.dNSName || name.getTagNo() == GeneralName.iPAddress)
-                .map(CertificateAuthorityService::generalNameToString)
-                .toList();
-    }
-
-    private static String generalNameToString(GeneralName name) {
-        if (name.getTagNo() == GeneralName.dNSName) {
-            return name.getName().toString();
-        }
-        try {
-            byte[] octets = ASN1OctetString.getInstance(name.getName()).getOctets();
-            return InetAddress.getByAddress(octets).getHostAddress();
-        } catch (Exception e) {
-            throw new AcmeException(400, "badCSR", "CSR contains an invalid IP subjectAltName");
-        }
-    }
-
-    private static boolean isIpAddress(String value) {
-        try {
-            InetAddress.getByName(value);
-            return value.indexOf(':') >= 0 || value.chars().allMatch(c -> Character.isDigit(c) || c == '.');
-        } catch (Exception e) {
-            return false;
-        }
     }
 
     String issuerPem() {

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertInfo.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertInfo.java
@@ -59,12 +59,15 @@ public final class CertInfo {
     public static Builder fromCsr(PKCS10CertificationRequest csr) {
         Objects.requireNonNull(csr, "csr must not be null");
         Builder builder = builder().subjectName(Csr.subjectName(csr));
-        for (String name : Csr.subjectAlternativeNames(csr)) {
-            if (Csr.isIpAddress(name)) {
-                builder.ipAddress(name);
-            } else {
-                builder.dnsName(name);
-            }
+        // Carry the dNSName / iPAddress tag through from the CSR rather than
+        // re-detecting from the string - a CSR dNSName like "10.0.0.1"
+        // (numeric labels are valid DNS) must stay a DNS SAN on the issued
+        // cert.
+        for (String name : Csr.dnsSubjectAlternativeNames(csr)) {
+            builder.dnsName(name);
+        }
+        for (String ip : Csr.ipSubjectAlternativeNames(csr)) {
+            builder.ipAddress(ip);
         }
         return builder;
     }

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertInfo.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertInfo.java
@@ -1,5 +1,7 @@
 package com.elevenware.quickpki;
 
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,6 +45,28 @@ public final class CertInfo {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    /**
+     * Returns a {@link Builder} pre-populated with the subject DN and SAN
+     * entries (dNSName / iPAddress) from {@code csr}. Validity and key/usage
+     * fields are left at their defaults so the caller can layer their own
+     * policy on top (eg. ACME validators that restrict SANs to validated
+     * identifiers). This factory does not verify the CSR's signature;
+     * {@link QuickPki#issueCertificate(PKCS10CertificationRequest, CertInfo)}
+     * does that at issuance time.
+     */
+    public static Builder fromCsr(PKCS10CertificationRequest csr) {
+        Objects.requireNonNull(csr, "csr must not be null");
+        Builder builder = builder().subjectName(Csr.subjectName(csr));
+        for (String name : Csr.subjectAlternativeNames(csr)) {
+            if (Csr.isIpAddress(name)) {
+                builder.ipAddress(name);
+            } else {
+                builder.dnsName(name);
+            }
+        }
+        return builder;
     }
 
     public SubjectName getSubjectName() {

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/Csr.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/Csr.java
@@ -91,9 +91,33 @@ public final class Csr {
     }
 
     /**
-     * Returns the dNSName and iPAddress entries from the CSR's requested
-     * subjectAltName extension. Mixed types in source order; empty list if the
-     * CSR omitted the extension or it contained only other GeneralName types.
+     * Returns the dNSName entries from the CSR's requested subjectAltName
+     * extension, in source order. Empty list if the CSR omitted the extension
+     * or contained no dNSName entries.
+     */
+    public static List<String> dnsSubjectAlternativeNames(PKCS10CertificationRequest csr) {
+        return sansOfTag(csr, GeneralName.dNSName);
+    }
+
+    /**
+     * Returns the iPAddress entries from the CSR's requested subjectAltName
+     * extension, in source order. Each entry is the textual form (dotted-quad
+     * for v4, colon-hex for v6). Empty list if the CSR omitted the extension
+     * or contained no iPAddress entries.
+     */
+    public static List<String> ipSubjectAlternativeNames(PKCS10CertificationRequest csr) {
+        return sansOfTag(csr, GeneralName.iPAddress);
+    }
+
+    /**
+     * Returns dNSName and iPAddress entries from the CSR's requested
+     * subjectAltName extension mixed together as strings, in source order.
+     * The tag is lost - callers that need to round-trip the type (eg. when
+     * building a new SAN extension on the issued cert) must use
+     * {@link #dnsSubjectAlternativeNames(PKCS10CertificationRequest)} and
+     * {@link #ipSubjectAlternativeNames(PKCS10CertificationRequest)}
+     * instead, otherwise a dNSName that happens to look like an IP literal
+     * (numeric labels are valid DNS syntax) will be silently re-typed.
      */
     public static List<String> subjectAlternativeNames(PKCS10CertificationRequest csr) {
         Objects.requireNonNull(csr, "csr must not be null");
@@ -117,22 +141,53 @@ public final class Csr {
     }
 
     /**
-     * Best-effort classification of a SAN string as an IP literal (v4 or v6)
-     * rather than a DNS name. Matches what the SAN extension would emit for
-     * the value.
+     * Returns true if {@code value} is an IP literal (dotted-quad IPv4 or
+     * colon-bearing IPv6). Shape-checks the string before any parser call so a
+     * DNS name never triggers a name-service lookup.
+     * <p>
+     * This is a heuristic on bare strings; callers that already have a CSR in
+     * hand should use {@link #dnsSubjectAlternativeNames} /
+     * {@link #ipSubjectAlternativeNames} to preserve the actual SAN tag
+     * rather than re-classify by shape.
      */
     public static boolean isIpAddress(String value) {
         Objects.requireNonNull(value, "value must not be null");
+        boolean looksLikeV6 = value.indexOf(':') >= 0;
+        boolean looksLikeV4 = !value.isEmpty()
+                && value.chars().allMatch(c -> Character.isDigit(c) || c == '.');
+        if (!looksLikeV4 && !looksLikeV6) {
+            return false;
+        }
         try {
             InetAddress.getByName(value);
+            return true;
         } catch (Exception e) {
             return false;
         }
-        // getByName resolves DNS too; restrict to literal forms (digits/dots
-        // for v4, colon-bearing for v6) so we don't classify "example.com" as
-        // an IP just because it resolves.
-        return value.indexOf(':') >= 0
-                || value.chars().allMatch(c -> Character.isDigit(c) || c == '.');
+    }
+
+    private static List<String> sansOfTag(PKCS10CertificationRequest csr, int tagNo) {
+        Objects.requireNonNull(csr, "csr must not be null");
+        Extensions extensions = csr.getRequestedExtensions();
+        if (extensions == null) {
+            return List.of();
+        }
+        GeneralNames generalNames = GeneralNames.fromExtensions(extensions, Extension.subjectAlternativeName);
+        if (generalNames == null) {
+            return List.of();
+        }
+        List<String> result = new ArrayList<>();
+        for (GeneralName name : generalNames.getNames()) {
+            if (name.getTagNo() != tagNo) {
+                continue;
+            }
+            if (tagNo == GeneralName.iPAddress) {
+                result.add(decodeIpAddress(name));
+            } else {
+                result.add(name.getName().toString());
+            }
+        }
+        return List.copyOf(result);
     }
 
     private static String decodeIpAddress(GeneralName name) {

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/Csr.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/Csr.java
@@ -1,0 +1,164 @@
+package com.elevenware.quickpki;
+
+import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.x500.RDN;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x500.style.IETFUtils;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
+
+import java.net.InetAddress;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Helpers for {@link PKCS10CertificationRequest} (CSR) introspection.
+ * <p>
+ * Used by {@link QuickPki#issueCertificate(PKCS10CertificationRequest)} and
+ * {@link CertInfo#fromCsr(PKCS10CertificationRequest)}, and exposed for callers
+ * that need to apply their own policy on top of CSR contents (eg. ACME servers
+ * filtering SANs against validated identifiers).
+ */
+public final class Csr {
+
+    private Csr() {}
+
+    /**
+     * Verifies the CSR's self-signature using the public key embedded in it.
+     * Throws if the signature is invalid or cannot be verified - never silently
+     * accepts an unverifiable CSR.
+     *
+     * @throws QuickPkiException if the signature is invalid or verification fails
+     */
+    public static void verifySignature(PKCS10CertificationRequest csr) {
+        Objects.requireNonNull(csr, "csr must not be null");
+        Provider provider = ensureBouncyCastleProvider();
+        try {
+            boolean valid = csr.isSignatureValid(new JcaContentVerifierProviderBuilder()
+                    .setProvider(provider)
+                    .build(csr.getSubjectPublicKeyInfo()));
+            if (!valid) {
+                throw new QuickPkiException("CSR signature is invalid");
+            }
+        } catch (QuickPkiException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new QuickPkiException("Failed to verify CSR signature", e);
+        }
+    }
+
+    /**
+     * Extracts the subscriber's public key from the CSR.
+     */
+    public static PublicKey publicKey(PKCS10CertificationRequest csr) {
+        Objects.requireNonNull(csr, "csr must not be null");
+        try {
+            return new JcaPKCS10CertificationRequest(csr)
+                    .setProvider(ensureBouncyCastleProvider())
+                    .getPublicKey();
+        } catch (Exception e) {
+            throw new QuickPkiException("Failed to extract public key from CSR", e);
+        }
+    }
+
+    /**
+     * Converts the CSR's subject DN into a {@link SubjectName}. RDNs the
+     * SubjectName builder doesn't model are silently dropped.
+     */
+    public static SubjectName subjectName(PKCS10CertificationRequest csr) {
+        Objects.requireNonNull(csr, "csr must not be null");
+        X500Name subject = csr.getSubject();
+        SubjectName.Builder builder = SubjectName.builder();
+        applyRdn(subject, BCStyle.CN, builder::commonName);
+        applyRdn(subject, BCStyle.C, builder::country);
+        applyRdn(subject, BCStyle.O, builder::organization);
+        applyRdn(subject, BCStyle.OU, builder::organizationUnit);
+        applyRdn(subject, BCStyle.DN_QUALIFIER, builder::dnQualifier);
+        applyRdn(subject, BCStyle.L, builder::locality);
+        applyRdn(subject, BCStyle.ST, builder::stateOrProvince);
+        return builder.build();
+    }
+
+    /**
+     * Returns the dNSName and iPAddress entries from the CSR's requested
+     * subjectAltName extension. Mixed types in source order; empty list if the
+     * CSR omitted the extension or it contained only other GeneralName types.
+     */
+    public static List<String> subjectAlternativeNames(PKCS10CertificationRequest csr) {
+        Objects.requireNonNull(csr, "csr must not be null");
+        Extensions extensions = csr.getRequestedExtensions();
+        if (extensions == null) {
+            return List.of();
+        }
+        GeneralNames generalNames = GeneralNames.fromExtensions(extensions, Extension.subjectAlternativeName);
+        if (generalNames == null) {
+            return List.of();
+        }
+        List<String> result = new ArrayList<>();
+        for (GeneralName name : generalNames.getNames()) {
+            if (name.getTagNo() == GeneralName.dNSName) {
+                result.add(name.getName().toString());
+            } else if (name.getTagNo() == GeneralName.iPAddress) {
+                result.add(decodeIpAddress(name));
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    /**
+     * Best-effort classification of a SAN string as an IP literal (v4 or v6)
+     * rather than a DNS name. Matches what the SAN extension would emit for
+     * the value.
+     */
+    public static boolean isIpAddress(String value) {
+        Objects.requireNonNull(value, "value must not be null");
+        try {
+            InetAddress.getByName(value);
+        } catch (Exception e) {
+            return false;
+        }
+        // getByName resolves DNS too; restrict to literal forms (digits/dots
+        // for v4, colon-bearing for v6) so we don't classify "example.com" as
+        // an IP just because it resolves.
+        return value.indexOf(':') >= 0
+                || value.chars().allMatch(c -> Character.isDigit(c) || c == '.');
+    }
+
+    private static String decodeIpAddress(GeneralName name) {
+        try {
+            byte[] octets = ASN1OctetString.getInstance(name.getName()).getOctets();
+            return InetAddress.getByAddress(octets).getHostAddress();
+        } catch (Exception e) {
+            throw new QuickPkiException("CSR contains an invalid IP subjectAltName", e);
+        }
+    }
+
+    private static void applyRdn(X500Name name, org.bouncycastle.asn1.ASN1ObjectIdentifier oid,
+                                 java.util.function.Consumer<String> setter) {
+        RDN[] rdns = name.getRDNs(oid);
+        if (rdns == null || rdns.length == 0) {
+            return;
+        }
+        setter.accept(IETFUtils.valueToString(rdns[0].getFirst().getValue()));
+    }
+
+    private static Provider ensureBouncyCastleProvider() {
+        Provider provider = Security.getProvider(BouncyCastleProvider.PROVIDER_NAME);
+        if (provider == null) {
+            provider = new BouncyCastleProvider();
+            Security.addProvider(provider);
+        }
+        return provider;
+    }
+}

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
@@ -335,10 +335,14 @@ public class QuickPki {
     }
 
     /**
-     * Issues a leaf certificate from a PKCS#10 CSR, using the CSR's subject DN,
-     * SANs, and public key verbatim. The CSR's self-signature is verified
-     * before anything is signed - a CSR with a bad signature never produces a
-     * cert.
+     * Issues a leaf certificate from a PKCS#10 CSR, drawing the subject DN,
+     * SANs, and public key from the CSR. The dNSName / iPAddress tag on each
+     * SAN is preserved from the CSR (a CSR dNSName that happens to look like
+     * an IP literal stays a DNS SAN). The subject DN is copied via
+     * {@link CertInfo#fromCsr(PKCS10CertificationRequest)}, which models the
+     * common RDNs (CN, C, O, OU, dnQualifier, L, ST) - other RDNs in the CSR
+     * are dropped. The CSR's self-signature is verified before anything is
+     * signed; a CSR with a bad signature never produces a cert.
      * <p>
      * The returned bundle carries no private key (the subscriber kept it); see
      * {@link #issueCertificate(CertInfo, PublicKey)} for the caveats around

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
@@ -19,6 +19,7 @@ import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
@@ -331,6 +332,40 @@ public class QuickPki {
         } catch (Exception e) {
             throw new QuickPkiException("Failed to issue certificate", e);
         }
+    }
+
+    /**
+     * Issues a leaf certificate from a PKCS#10 CSR, using the CSR's subject DN,
+     * SANs, and public key verbatim. The CSR's self-signature is verified
+     * before anything is signed - a CSR with a bad signature never produces a
+     * cert.
+     * <p>
+     * The returned bundle carries no private key (the subscriber kept it); see
+     * {@link #issueCertificate(CertInfo, PublicKey)} for the caveats around
+     * such bundles.
+     *
+     * @throws QuickPkiException if the CSR signature is invalid or issuance fails
+     */
+    public CertificateBundle issueCertificate(PKCS10CertificationRequest csr) {
+        Objects.requireNonNull(csr, "csr must not be null");
+        return issueCertificate(csr, CertInfo.fromCsr(csr).build());
+    }
+
+    /**
+     * Issues a leaf certificate from a PKCS#10 CSR, but with {@code info}
+     * overriding the CSR's subject/SANs/validity/usages. The CSR contributes
+     * only the public key (and the signature that proves the subscriber
+     * possesses the matching private key). Intended for callers that apply
+     * their own policy on top of CSR contents - eg. ACME servers that
+     * restrict SANs to validated identifiers.
+     *
+     * @throws QuickPkiException if the CSR signature is invalid or issuance fails
+     */
+    public CertificateBundle issueCertificate(PKCS10CertificationRequest csr, CertInfo info) {
+        Objects.requireNonNull(csr, "csr must not be null");
+        Objects.requireNonNull(info, "info must not be null");
+        Csr.verifySignature(csr);
+        return issueCertificate(info, Csr.publicKey(csr));
     }
 
     // Issues a subordinate CA certificate, signed by this PKI, and returns it

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
@@ -1217,6 +1217,43 @@ public class PkiTests {
     }
 
     @Test
+    void issueFromCsrPreservesSanTagForNumericDnsName() throws Exception {
+        // Regression: a CSR dNSName whose string happens to look like an IPv4
+        // literal must stay a DNS SAN on the issued cert. Numeric labels are
+        // valid DNS syntax (RFC 1123), so the tag, not the shape, is the
+        // source of truth.
+        QuickPki pki = QuickPki.createDefault();
+        KeyPair subscriberKeys = generateRsaKeyPair();
+        PKCS10CertificationRequest csr = buildCsr(subscriberKeys,
+                "CN=10.0.0.1",
+                List.of("10.0.0.1"),
+                List.of());
+
+        CertificateBundle bundle = pki.issueCertificate(csr);
+
+        Collection<List<?>> sans = bundle.getCertificate().getSubjectAlternativeNames();
+        assertNotNull(sans);
+        List<List<?>> entries = new ArrayList<>(sans);
+        assertEquals(1, entries.size(), "expected exactly one SAN entry");
+        // GeneralName tag 2 = dNSName, 7 = iPAddress. The CSR carried tag 2;
+        // the issued cert must too.
+        assertEquals(2, ((Number) entries.get(0).get(0)).intValue(),
+                "SAN tag should be dNSName(2), got " + entries.get(0).get(0));
+        assertEquals("10.0.0.1", entries.get(0).get(1));
+    }
+
+    @Test
+    void csrIsIpAddressDoesNotResolveDnsNames() {
+        // Shape-checking before InetAddress.getByName avoids accidental
+        // network lookups on typical DNS names. Anything not made of
+        // digits/dots (v4) or containing a colon (v6) must short-circuit.
+        assertFalse(Csr.isIpAddress("example.com"));
+        assertFalse(Csr.isIpAddress("a-host"));
+        assertTrue(Csr.isIpAddress("10.0.0.1"));
+        assertTrue(Csr.isIpAddress("::1"));
+    }
+
+    @Test
     void certInfoFromCsrCopiesSubjectAndSans() throws Exception {
         KeyPair subscriberKeys = generateRsaKeyPair();
         PKCS10CertificationRequest csr = buildCsr(subscriberKeys,

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
@@ -5,7 +5,10 @@ import com.nimbusds.jose.jwk.JWKSet;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.ExtensionsGenerator;
 import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 import org.bouncycastle.cert.X509CertificateHolder;
@@ -13,6 +16,11 @@ import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -1124,6 +1132,138 @@ public class PkiTests {
 
         assertThrows(IllegalArgumentException.class,
                 () -> CertInfo.builder().keyUsage(KeyUsageBit.CRL_SIGN));
+    }
+
+    @Test
+    void canIssueCertificateFromCsr() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+        KeyPair subscriberKeys = generateRsaKeyPair();
+
+        PKCS10CertificationRequest csr = buildCsr(subscriberKeys,
+                "CN=csr.example.com,O=Subscriber Co",
+                List.of("csr.example.com", "alt.example.com"),
+                List.of("10.0.0.1"));
+
+        CertificateBundle bundle = pki.issueCertificate(csr);
+
+        assertEquals(subscriberKeys.getPublic(), bundle.getCertificate().getPublicKey());
+        assertNull(bundle.getKeyPair().getPrivate(),
+                "CSR-issued bundle must not carry a private key");
+        assertTrue(bundle.issuedBy(pki.getIssuer()));
+        assertEquals("csr.example.com", bundle.getCommonName());
+
+        Collection<List<?>> sans = bundle.getCertificate().getSubjectAlternativeNames();
+        assertNotNull(sans);
+        Set<String> sanValues = new HashSet<>();
+        for (List<?> entry : sans) {
+            sanValues.add(entry.get(1).toString());
+        }
+        assertTrue(sanValues.contains("csr.example.com"));
+        assertTrue(sanValues.contains("alt.example.com"));
+        assertTrue(sanValues.contains("10.0.0.1"));
+    }
+
+    @Test
+    void issueFromCsrRejectsInvalidSignature() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+        KeyPair subscriberKeys = generateRsaKeyPair();
+        PKCS10CertificationRequest csr = buildCsr(subscriberKeys,
+                "CN=tampered.example.com", List.of("tampered.example.com"), List.of());
+
+        // Re-decode after flipping a signature byte. PKCS10CertificationRequest
+        // is immutable, so we corrupt the DER and re-parse to get a CSR whose
+        // SubjectPublicKeyInfo no longer matches its signature.
+        byte[] der = csr.getEncoded();
+        der[der.length - 1] ^= 0x01;
+        PKCS10CertificationRequest tampered = new PKCS10CertificationRequest(der);
+
+        QuickPkiException ex = assertThrows(QuickPkiException.class,
+                () -> pki.issueCertificate(tampered));
+        assertTrue(ex.getMessage().toLowerCase().contains("signature"),
+                "exception should mention signature, got: " + ex.getMessage());
+    }
+
+    @Test
+    void issueFromCsrWithOverridesUsesCertInfoNotCsrFields() throws Exception {
+        // ACME-style policy: caller built its own CertInfo (perhaps filtering
+        // SANs from the CSR against a validated set). The lib should sign
+        // exactly what the caller asked for, using the CSR only as the
+        // public-key + proof-of-possession source.
+        QuickPki pki = QuickPki.createDefault();
+        KeyPair subscriberKeys = generateRsaKeyPair();
+        PKCS10CertificationRequest csr = buildCsr(subscriberKeys,
+                "CN=requested.example.com",
+                List.of("requested.example.com", "evil.example.com"),
+                List.of());
+
+        CertInfo overrides = CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("policy.example.com").build())
+                .dnsName("policy.example.com")
+                .build();
+
+        CertificateBundle bundle = pki.issueCertificate(csr, overrides);
+
+        assertEquals(subscriberKeys.getPublic(), bundle.getCertificate().getPublicKey());
+        assertEquals("policy.example.com", bundle.getCommonName());
+
+        Collection<List<?>> sans = bundle.getCertificate().getSubjectAlternativeNames();
+        assertNotNull(sans);
+        Set<String> sanValues = new HashSet<>();
+        for (List<?> entry : sans) {
+            sanValues.add(entry.get(1).toString());
+        }
+        assertEquals(Set.of("policy.example.com"), sanValues,
+                "overrides CertInfo must win over CSR-declared SANs");
+    }
+
+    @Test
+    void certInfoFromCsrCopiesSubjectAndSans() throws Exception {
+        KeyPair subscriberKeys = generateRsaKeyPair();
+        PKCS10CertificationRequest csr = buildCsr(subscriberKeys,
+                "CN=copy.example.com,O=Copier,OU=Eng",
+                List.of("copy.example.com"),
+                List.of("192.168.1.5"));
+
+        CertInfo info = CertInfo.fromCsr(csr).build();
+
+        assertEquals("copy.example.com", info.getSubjectName().getCommonName());
+        assertEquals("Copier", info.getSubjectName().getOrganization());
+        assertEquals("Eng", info.getSubjectName().getOrganizationUnit());
+        assertEquals(List.of("copy.example.com"), info.getDnsNames());
+        assertEquals(List.of("192.168.1.5"), info.getIpAddresses());
+    }
+
+    private static KeyPair generateRsaKeyPair() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        return generator.generateKeyPair();
+    }
+
+    private static PKCS10CertificationRequest buildCsr(KeyPair keys, String subjectDn,
+                                                       List<String> dnsNames,
+                                                       List<String> ipAddresses) throws Exception {
+        X500Name subject = new X500Name(subjectDn);
+        PKCS10CertificationRequestBuilder builder =
+                new JcaPKCS10CertificationRequestBuilder(subject, keys.getPublic());
+        if (!dnsNames.isEmpty() || !ipAddresses.isEmpty()) {
+            List<GeneralName> names = new ArrayList<>();
+            for (String dns : dnsNames) {
+                names.add(new GeneralName(GeneralName.dNSName, dns));
+            }
+            for (String ip : ipAddresses) {
+                names.add(new GeneralName(GeneralName.iPAddress, ip));
+            }
+            ExtensionsGenerator extGen = new ExtensionsGenerator();
+            extGen.addExtension(Extension.subjectAlternativeName, false,
+                    new GeneralNames(names.toArray(new GeneralName[0])));
+            builder.addAttribute(
+                    org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers.pkcs_9_at_extensionRequest,
+                    extGen.generate());
+        }
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(keys.getPrivate());
+        return builder.build(signer);
     }
 
     @BeforeAll


### PR DESCRIPTION
Lifts CSR parsing from the ACME server into the library so any caller can issue from a CSR without re-implementing signature verification, SAN extraction, and IP decoding. Two new QuickPki overloads (issueCertificate(csr) and issueCertificate(csr, info)) cover the verbatim and policy-overridden cases respectively; both verify the CSR signature before signing.