### PR TITLE
Fix Docker image build broken by the new cert-api module

### DIFF
--- a/quick-pki-acme-server/Dockerfile
+++ b/quick-pki-acme-server/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /workspace
 COPY pom.xml .
 COPY quick-pki-lib/pom.xml quick-pki-lib/pom.xml
 COPY quick-pki-acme-server/pom.xml quick-pki-acme-server/pom.xml
+COPY quick-pki-cert-api/pom.xml quick-pki-cert-api/pom.xml
 RUN mvn -pl quick-pki-acme-server -am dependency:go-offline
 COPY quick-pki-lib quick-pki-lib
 COPY quick-pki-acme-server quick-pki-acme-server

--- a/quick-pki-cert-api/Dockerfile
+++ b/quick-pki-cert-api/Dockerfile
@@ -2,6 +2,7 @@ FROM maven:3.9.9-eclipse-temurin-17 AS build
 WORKDIR /workspace
 COPY pom.xml .
 COPY quick-pki-lib/pom.xml quick-pki-lib/pom.xml
+COPY quick-pki-acme-server/pom.xml quick-pki-acme-server/pom.xml
 COPY quick-pki-cert-api/pom.xml quick-pki-cert-api/pom.xml
 RUN mvn -pl quick-pki-cert-api -am dependency:go-offline
 COPY quick-pki-lib quick-pki-lib


### PR DESCRIPTION
## Summary

The `Build and publish Docker images` workflow started failing after
`quick-pki-cert-api` was merged.

**Root cause:** `quick-pki-acme-server/Dockerfile` copies module poms
individually (a layer-caching optimisation) before running Maven. The
root aggregator pom now declares three modules, but the Dockerfile only
copied `pom.xml`, `quick-pki-lib/pom.xml`, and
`quick-pki-acme-server/pom.xml`. Maven refuses to read the reactor when
a declared child module's pom is absent:

```
[ERROR] Child module /workspace/quick-pki-cert-api of /workspace/pom.xml does not exist
```

so the `quick-pki-acme-server` image build fails before compiling
anything. (The `quick-pki-admin` matrix entry is a Go build and is
unaffected.)

## Changes

- `quick-pki-acme-server/Dockerfile`: also copy `quick-pki-cert-api/pom.xml`.
- `quick-pki-cert-api/Dockerfile`: also copy `quick-pki-acme-server/pom.xml`
  — the same omission in reverse, latent because cert-api is not yet in
  the publish matrix.

## Test plan

- [x] Reproduced the failure by mimicking the Dockerfile's pre-build
  copy state and running `mvn -pl quick-pki-acme-server -am validate`
  (errored with the "Child module ... does not exist" message)
- [x] Re-ran the same validate with all three module poms present — succeeds
- [ ] Confirm the `Build and publish Docker images` workflow goes green on merge

https://claude.ai/code/session_01JGNZteozwU77cntHvBTy98

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGNZteozwU77cntHvBTy98)_