### PR TITLE
Add optional remote certificate API issuance to ACME server

### DIFF
--- a/quick-pki-acme-server/README.md
+++ b/quick-pki-acme-server/README.md
@@ -4,9 +4,17 @@ Runnable internal ACME service backed by Quick-PKI, Javalin, Postgres, and Liqui
 
 ## Configuration
 
+The server issues certificates in one of two modes:
+
+- **Local CA** (default): mints certificates from a CA it holds and persists itself.
+- **Remote API**: delegates issuance to a deployed Quick-PKI certificate API,
+  selected by setting `ACME_CERT_API_URL`.
+
 Required:
 
-- `ACME_CA_KEY_PASSWORD`: password used to derive the AES-GCM key for CA private key encryption at rest.
+- `ACME_CA_KEY_PASSWORD`: password used to derive the AES-GCM key for CA private
+  key encryption at rest. Required in local CA mode only; not needed when issuance
+  is delegated to a remote certificate API.
 
 Common:
 
@@ -18,6 +26,28 @@ Common:
 - `JDBC_PASSWORD`, default `quickpki`
 - `ACME_CERTIFICATE_DAYS`, default `90`
 - `ACME_DNS_SERVERS`, optional comma-separated DNS servers for DNS-01 validation
+
+### Delegating issuance to a remote certificate API
+
+Set `ACME_CERT_API_URL` to point the server at a deployed certificate issuance
+API instead of running its own CA. In this mode the server still validates ACME
+challenges and enforces that a finalize CSR only contains validated SANs, but
+forwards the CSR to the API for signing. The certificate API is an OAuth 2.0
+protected resource, so client credentials are required to obtain access tokens
+via the client credentials grant.
+
+- `ACME_CERT_API_URL`: base URL of the certificate API (e.g. `https://certs.example.com`).
+  Setting this enables remote mode.
+- `ACME_CERT_API_TOKEN_URL`: OAuth 2.0 token endpoint used for the client
+  credentials grant. Required in remote mode.
+- `ACME_CERT_API_CLIENT_ID` / `ACME_CERT_API_CLIENT_SECRET`: confidential client
+  credentials used to obtain access tokens. Required in remote mode.
+- `ACME_CERT_API_SCOPE`: optional scope requested with the client credentials grant.
+- `ACME_CERT_API_TIMEOUT_SECONDS`: optional HTTP timeout for token and issuance
+  calls, default `10`.
+
+The `POST /admin/ca/rotate` endpoint is unavailable in remote mode, since the
+issuing CA is owned by the certificate API.
 
 ## Local Run
 

--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/AcmeConfig.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/AcmeConfig.java
@@ -17,16 +17,43 @@ record AcmeConfig(
         Duration authzLifetime,
         Duration challengeTimeout,
         int challengeAttempts,
-        List<String> dnsServers
+        List<String> dnsServers,
+        RemoteIssuerConfig remoteIssuer
 ) {
+
+    /**
+     * Settings for delegating certificate issuance to a deployed certificate
+     * API instead of minting certificates locally.
+     * <p>
+     * Present only when {@code ACME_CERT_API_URL} is set; a {@code null}
+     * {@link #remoteIssuer()} means the server runs its own CA. The credentials
+     * are used for the OAuth 2.0 client credentials grant against
+     * {@code tokenUrl} to obtain tokens for calls to {@code apiUrl}.
+     */
+    record RemoteIssuerConfig(
+            String apiUrl,
+            String tokenUrl,
+            String clientId,
+            String clientSecret,
+            String scope,
+            Duration timeout
+    ) {
+    }
 
     static AcmeConfig fromEnv() {
         int port = intEnv("PORT", 8080);
         String externalUrl = trimTrailingSlash(env("ACME_EXTERNAL_URL", "http://localhost:" + port));
         URI.create(externalUrl);
+
+        RemoteIssuerConfig remoteIssuer = remoteIssuerFromEnv();
+
+        // The CA key password protects the locally minted CA's private key. It
+        // is irrelevant when issuance is delegated to a remote certificate API,
+        // so it is only required in local mode.
         String caKeyPassword = env("ACME_CA_KEY_PASSWORD", null);
-        if (caKeyPassword == null || caKeyPassword.length() < 12) {
-            throw new IllegalArgumentException("ACME_CA_KEY_PASSWORD must be set and at least 12 characters");
+        if (remoteIssuer == null && (caKeyPassword == null || caKeyPassword.length() < 12)) {
+            throw new IllegalArgumentException("ACME_CA_KEY_PASSWORD must be set and at least 12 characters "
+                    + "unless ACME_CERT_API_URL delegates issuance to a remote certificate API");
         }
         return new AcmeConfig(
                 port,
@@ -40,8 +67,35 @@ record AcmeConfig(
                 Duration.ofHours(intEnv("ACME_AUTHZ_HOURS", 1)),
                 Duration.ofSeconds(intEnv("ACME_CHALLENGE_TIMEOUT_SECONDS", 5)),
                 intEnv("ACME_CHALLENGE_ATTEMPTS", 3),
-                csvEnv("ACME_DNS_SERVERS")
+                csvEnv("ACME_DNS_SERVERS"),
+                remoteIssuer
         );
+    }
+
+    private static RemoteIssuerConfig remoteIssuerFromEnv() {
+        String apiUrl = env("ACME_CERT_API_URL", null);
+        if (apiUrl == null) {
+            return null;
+        }
+        apiUrl = trimTrailingSlash(apiUrl);
+        URI.create(apiUrl);
+
+        String tokenUrl = env("ACME_CERT_API_TOKEN_URL", null);
+        String clientId = env("ACME_CERT_API_CLIENT_ID", null);
+        String clientSecret = env("ACME_CERT_API_CLIENT_SECRET", null);
+        if (tokenUrl == null || clientId == null || clientSecret == null) {
+            throw new IllegalArgumentException("ACME_CERT_API_URL requires ACME_CERT_API_TOKEN_URL, "
+                    + "ACME_CERT_API_CLIENT_ID and ACME_CERT_API_CLIENT_SECRET so the ACME server can "
+                    + "obtain access tokens via the OAuth 2.0 client credentials grant");
+        }
+        URI.create(tokenUrl);
+        return new RemoteIssuerConfig(
+                apiUrl,
+                tokenUrl,
+                clientId,
+                clientSecret,
+                env("ACME_CERT_API_SCOPE", null),
+                Duration.ofSeconds(intEnv("ACME_CERT_API_TIMEOUT_SECONDS", 10)));
     }
 
     String url(String path) {

--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/AcmeServer.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/AcmeServer.java
@@ -27,7 +27,7 @@ final class AcmeServer {
 
     private final AcmeConfig config;
     private final AcmeRepository repository;
-    private final AtomicReference<CertificateAuthorityService> caService;
+    private final AtomicReference<CertificateIssuer> certificateIssuer;
     private final NonceService nonceService;
     private final AcmeJwsService jwsService;
     private final ChallengeValidationService challengeValidationService;
@@ -35,13 +35,13 @@ final class AcmeServer {
     AcmeServer(
             AcmeConfig config,
             AcmeRepository repository,
-            CertificateAuthorityService caService,
+            CertificateIssuer certificateIssuer,
             NonceService nonceService,
             AcmeJwsService jwsService,
             ChallengeValidationService challengeValidationService) {
         this.config = config;
         this.repository = repository;
-        this.caService = new AtomicReference<>(caService);
+        this.certificateIssuer = new AtomicReference<>(certificateIssuer);
         this.nonceService = nonceService;
         this.jwsService = jwsService;
         this.challengeValidationService = challengeValidationService;
@@ -85,7 +85,7 @@ final class AcmeServer {
         routes.post("/acme/finalize/{id}", this::finalizeOrder);
         routes.post("/acme/cert/{id}", this::certificate);
         routes.get("/issuer/root.pem", ctx -> ctx.contentType("application/pem-certificate-chain")
-                .result(caService.get().issuerPem()));
+                .result(certificateIssuer.get().issuerPem()));
         routes.post("/admin/ca/rotate", this::rotateCa);
         routes.post("/ocsp", this::ocsp);
         routes.get("/healthz", ctx -> ctx.result("ok"));
@@ -226,7 +226,7 @@ final class AcmeServer {
                 .filter(a -> "valid".equals(a.status()))
                 .map(Authorization::identifier)
                 .toList();
-        CertificateAuthorityService.IssuedCertificate issued = caService.get().issue(csrDer, validIdentifiers);
+        CertificateIssuer.IssuedCertificate issued = certificateIssuer.get().issue(csrDer, validIdentifiers);
         repository.finalizeOrder(order.id(), csrDer, issued.certificatePem(), issued.chainPem());
         LOG.info("Finalized ACME order orderId={} accountId={} identifiers={}",
                 order.id(), request.account().id(), validIdentifiers);
@@ -258,8 +258,12 @@ final class AcmeServer {
 
     private void rotateCa(Context ctx) {
         requireAdmin(ctx);
+        if (config.remoteIssuer() != null) {
+            throw new AcmeException(409, "rotationUnsupported",
+                    "CA rotation is unavailable: this server delegates issuance to a remote certificate API");
+        }
         CertificateAuthorityService rotated = CertificateAuthorityService.rotate(config, repository);
-        caService.set(rotated);
+        certificateIssuer.set(rotated);
         LOG.warn("Rotated active ACME CA issuerName={}", rotated.issuerName());
         ctx.json(Map.of(
                 "issuerName", rotated.issuerName(),

--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/CertificateAuthorityService.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/CertificateAuthorityService.java
@@ -2,7 +2,6 @@ package com.elevenware.quickpki.acme;
 
 import com.elevenware.quickpki.CertInfo;
 import com.elevenware.quickpki.CertificateBundle;
-import com.elevenware.quickpki.Csr;
 import com.elevenware.quickpki.ExtendedKeyUsageId;
 import com.elevenware.quickpki.IssuerInfo;
 import com.elevenware.quickpki.QuickPki;
@@ -10,7 +9,6 @@ import com.elevenware.quickpki.SubjectName;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
-import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,11 +23,9 @@ import java.security.cert.X509Certificate;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
-final class CertificateAuthorityService {
+final class CertificateAuthorityService implements CertificateIssuer {
 
     private static final Logger LOG = LoggerFactory.getLogger(CertificateAuthorityService.class);
 
@@ -62,63 +58,30 @@ final class CertificateAuthorityService {
         return issuer;
     }
 
-    IssuedCertificate issue(byte[] csrDer, List<Identifier> validatedIdentifiers) {
+    @Override
+    public IssuedCertificate issue(byte[] csrDer, List<Identifier> validatedIdentifiers) {
         try {
-            PKCS10CertificationRequest csr = new PKCS10CertificationRequest(csrDer);
-
-            // Filter per-type: a validated "dns:example.com" identifier
-            // authorises a dNSName SAN, not an iPAddress SAN of the same
-            // string. Carrying the tag through avoids issuing a cert whose
-            // SAN type disagrees with what was actually validated.
-            Set<String> allowedDns = identifierValuesOfType(validatedIdentifiers, "dns");
-            Set<String> allowedIp = identifierValuesOfType(validatedIdentifiers, "ip");
-
-            List<String> csrDnsNames = Csr.dnsSubjectAlternativeNames(csr);
-            List<String> csrIpNames = Csr.ipSubjectAlternativeNames(csr);
-
-            if (!csrDnsNames.stream().allMatch(allowedDns::contains)
-                    || !csrIpNames.stream().allMatch(allowedIp::contains)) {
-                throw new AcmeException(400, "badCSR",
-                        "CSR contains subjectAltName entries that were not validated");
-            }
-
-            List<String> dnsNames = csrDnsNames.stream().distinct().toList();
-            List<String> ipNames = csrIpNames.stream().distinct().toList();
-            if (dnsNames.isEmpty() && ipNames.isEmpty()) {
-                throw new AcmeException(400, "badCSR",
-                        "CSR must contain at least one validated subjectAltName");
-            }
-
-            // CN is just a label - take the first SAN in CSR source order so
-            // it stays stable across re-issuance.
-            String commonName = Csr.subjectAlternativeNames(csr).get(0);
+            CsrValidation.ValidatedCsr validated = CsrValidation.validate(csrDer, validatedIdentifiers);
 
             Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
             CertInfo.Builder cert = CertInfo.builder()
-                    .subjectName(SubjectName.builder().commonName(commonName).build())
+                    .subjectName(SubjectName.builder().commonName(validated.commonName()).build())
                     .validFrom(now.minus(5, ChronoUnit.MINUTES))
                     .validUntil(now.plus(config.certificateLifetime()))
                     .extendedKeyUsage(ExtendedKeyUsageId.SERVER_AUTH);
-            for (String dns : dnsNames) {
+            for (String dns : validated.dnsNames()) {
                 cert.dnsName(dns);
             }
-            for (String ip : ipNames) {
+            for (String ip : validated.ipNames()) {
                 cert.ipAddress(ip);
             }
-            CertificateBundle bundle = pki.issueCertificate(csr, cert.build());
+            CertificateBundle bundle = pki.issueCertificate(validated.csr(), cert.build());
             return new IssuedCertificate(bundle.toCertificatePem(), bundle.toCertificateChainPem());
         } catch (AcmeException e) {
             throw e;
         } catch (Exception e) {
             throw new AcmeException(400, "badCSR", "Failed to issue certificate from CSR: " + e.getMessage());
         }
-    }
-
-    private static Set<String> identifierValuesOfType(List<Identifier> identifiers, String type) {
-        return identifiers.stream()
-                .filter(id -> type.equalsIgnoreCase(id.type()))
-                .map(Identifier::value)
-                .collect(java.util.stream.Collectors.toCollection(HashSet::new));
     }
 
     private static CertificateAuthorityService load(
@@ -178,7 +141,8 @@ final class CertificateAuthorityService {
                 .build();
     }
 
-    String issuerPem() {
+    @Override
+    public String issuerPem() {
         return issuer.toCertificatePem();
     }
 
@@ -198,8 +162,5 @@ final class CertificateAuthorityService {
             throw new IllegalStateException("Failed to encode PEM", e);
         }
         return sw.toString();
-    }
-
-    record IssuedCertificate(String certificatePem, String chainPem) {
     }
 }

--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/CertificateIssuer.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/CertificateIssuer.java
@@ -1,0 +1,28 @@
+package com.elevenware.quickpki.acme;
+
+import java.util.List;
+
+/**
+ * Source of signed certificates for finalized ACME orders.
+ * <p>
+ * The ACME server either mints certificates from a CA it holds locally
+ * ({@link CertificateAuthorityService}) or delegates issuance to a deployed
+ * certificate API ({@link RemoteCertificateIssuer}). Which one is used is
+ * decided at startup from configuration, so the rest of the server depends
+ * only on this interface.
+ */
+interface CertificateIssuer {
+
+    /**
+     * Issues a certificate for the given PKCS#10 CSR. Implementations must only
+     * issue subjectAltName entries covered by {@code validatedIdentifiers};
+     * see {@link CsrValidation}.
+     */
+    IssuedCertificate issue(byte[] csrDer, List<Identifier> validatedIdentifiers);
+
+    /** PEM of the certificate that anchors the chain returned by {@link #issue}. */
+    String issuerPem();
+
+    record IssuedCertificate(String certificatePem, String chainPem) {
+    }
+}

--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/CsrValidation.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/CsrValidation.java
@@ -1,0 +1,78 @@
+package com.elevenware.quickpki.acme;
+
+import com.elevenware.quickpki.Csr;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Enforces that a finalize CSR only requests subjectAltName entries the order's
+ * authorizations actually validated.
+ * <p>
+ * This is an ACME protocol obligation that belongs to the ACME server no matter
+ * who signs the certificate: a remote certificate API issues whatever the CSR
+ * asks for and knows nothing about ACME authorizations, so the check runs here
+ * before either the local CA or the remote API sees the request.
+ */
+final class CsrValidation {
+
+    private CsrValidation() {
+    }
+
+    /**
+     * The parsed CSR plus the de-duplicated SAN entries it carries, ready to be
+     * handed to a CA. {@code commonName} is just a stable label for the subject.
+     */
+    record ValidatedCsr(
+            PKCS10CertificationRequest csr,
+            List<String> dnsNames,
+            List<String> ipNames,
+            String commonName) {
+    }
+
+    static ValidatedCsr validate(byte[] csrDer, List<Identifier> validatedIdentifiers) {
+        PKCS10CertificationRequest csr;
+        try {
+            csr = new PKCS10CertificationRequest(csrDer);
+        } catch (Exception e) {
+            throw new AcmeException(400, "badCSR", "Failed to parse PKCS#10 CSR: " + e.getMessage());
+        }
+
+        // Filter per-type: a validated "dns:example.com" identifier authorises a
+        // dNSName SAN, not an iPAddress SAN of the same string. Carrying the tag
+        // through avoids issuing a cert whose SAN type disagrees with what was
+        // actually validated.
+        Set<String> allowedDns = identifierValuesOfType(validatedIdentifiers, "dns");
+        Set<String> allowedIp = identifierValuesOfType(validatedIdentifiers, "ip");
+
+        List<String> csrDnsNames = Csr.dnsSubjectAlternativeNames(csr);
+        List<String> csrIpNames = Csr.ipSubjectAlternativeNames(csr);
+
+        if (!csrDnsNames.stream().allMatch(allowedDns::contains)
+                || !csrIpNames.stream().allMatch(allowedIp::contains)) {
+            throw new AcmeException(400, "badCSR",
+                    "CSR contains subjectAltName entries that were not validated");
+        }
+
+        List<String> dnsNames = csrDnsNames.stream().distinct().toList();
+        List<String> ipNames = csrIpNames.stream().distinct().toList();
+        if (dnsNames.isEmpty() && ipNames.isEmpty()) {
+            throw new AcmeException(400, "badCSR",
+                    "CSR must contain at least one validated subjectAltName");
+        }
+
+        // CN is just a label - take the first SAN in CSR source order so it
+        // stays stable across re-issuance.
+        return new ValidatedCsr(csr, dnsNames, ipNames, Csr.subjectAlternativeNames(csr).get(0));
+    }
+
+    private static Set<String> identifierValuesOfType(List<Identifier> identifiers, String type) {
+        return identifiers.stream()
+                .filter(id -> type.equalsIgnoreCase(id.type()))
+                .map(Identifier::value)
+                .collect(Collectors.toCollection(HashSet::new));
+    }
+}

--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/Main.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/Main.java
@@ -12,18 +12,21 @@ public final class Main {
 
     public static void main(String[] args) throws Exception {
         AcmeConfig config = AcmeConfig.fromEnv();
-        LOG.info("Starting Quick-PKI ACME server port={} externalUrl={} databaseUrl={} dnsServers={} certificateDays={} authzHours={}",
+        LOG.info("Starting Quick-PKI ACME server port={} externalUrl={} databaseUrl={} dnsServers={} certificateDays={} authzHours={} issuance={}",
                 config.port(),
                 config.externalUrl(),
                 config.databaseUrl(),
                 config.dnsServers(),
                 config.certificateLifetime().toDays(),
-                config.authzLifetime().toHours());
+                config.authzLifetime().toHours(),
+                config.remoteIssuer() == null ? "local-ca" : "remote-api");
         Database database = Database.open(config);
         database.migrate();
 
         AcmeRepository repository = new AcmeRepository(database.dataSource());
-        CertificateAuthorityService caService = CertificateAuthorityService.loadOrCreate(config, repository);
+        CertificateIssuer certificateIssuer = config.remoteIssuer() != null
+                ? RemoteCertificateIssuer.fromConfig(config.remoteIssuer())
+                : CertificateAuthorityService.loadOrCreate(config, repository);
         NonceService nonceService = new NonceService();
         AcmeJwsService jwsService = new AcmeJwsService(repository, nonceService);
         ChallengeValidationService challengeValidationService = new ChallengeValidationService(config);
@@ -31,7 +34,7 @@ public final class Main {
         AcmeServer server = new AcmeServer(
                 config,
                 repository,
-                caService,
+                certificateIssuer,
                 nonceService,
                 jwsService,
                 challengeValidationService

--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/RemoteCertificateIssuer.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/RemoteCertificateIssuer.java
@@ -1,0 +1,226 @@
+package com.elevenware.quickpki.acme;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.Security;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Delegates certificate issuance to a deployed Quick-PKI certificate API
+ * instead of minting certificates from a CA held by the ACME server itself.
+ * <p>
+ * The certificate API is an OAuth 2.0 protected resource, so this issuer is
+ * also an OAuth client: it obtains access tokens from a configured
+ * authorization server using the client credentials grant, caches them until
+ * they near expiry, and presents them as bearer tokens on each issuance call.
+ * SAN policy ({@link CsrValidation}) is still enforced here - the remote API
+ * has no knowledge of ACME authorizations.
+ */
+final class RemoteCertificateIssuer implements CertificateIssuer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RemoteCertificateIssuer.class);
+
+    // Used when the token response omits expires_in, and subtracted from a
+    // returned lifetime so a token is refreshed before an in-flight call
+    // races its expiry.
+    private static final long DEFAULT_TOKEN_TTL_SECONDS = 300;
+    private static final long TOKEN_REFRESH_SKEW_SECONDS = 30;
+
+    private final URI certificatesEndpoint;
+    private final URI issuerEndpoint;
+    private final URI tokenEndpoint;
+    private final String scope;
+    private final String basicAuth;
+    private final Duration timeout;
+    private final HttpClient http;
+
+    private String cachedToken;
+    private Instant tokenExpiresAt = Instant.EPOCH;
+    private String cachedIssuerPem;
+
+    private RemoteCertificateIssuer(AcmeConfig.RemoteIssuerConfig config) {
+        this.certificatesEndpoint = URI.create(config.apiUrl() + "/v1/certificates");
+        this.issuerEndpoint = URI.create(config.apiUrl() + "/issuer/root.pem");
+        this.tokenEndpoint = URI.create(config.tokenUrl());
+        this.scope = config.scope();
+        this.timeout = config.timeout();
+        this.basicAuth = "Basic " + Base64.getEncoder().encodeToString(
+                (config.clientId() + ":" + config.clientSecret()).getBytes(StandardCharsets.UTF_8));
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(config.timeout())
+                .build();
+    }
+
+    static RemoteCertificateIssuer fromConfig(AcmeConfig.RemoteIssuerConfig config) {
+        // CSR parsing in CsrValidation relies on BouncyCastle; the local CA
+        // registers it, but in remote mode that code path never runs.
+        Security.addProvider(new BouncyCastleProvider());
+        LOG.info("ACME issuance delegated to remote certificate API url={} tokenUrl={} clientId={} scope={}",
+                config.apiUrl(), config.tokenUrl(), config.clientId(),
+                config.scope() == null ? "(none)" : config.scope());
+        return new RemoteCertificateIssuer(config);
+    }
+
+    @Override
+    public IssuedCertificate issue(byte[] csrDer, List<Identifier> validatedIdentifiers) {
+        // Enforce ACME's "only validated SANs" rule before the CSR leaves this
+        // process: the remote API issues whatever the CSR asks for.
+        CsrValidation.validate(csrDer, validatedIdentifiers);
+
+        String body;
+        try {
+            body = Json.MAPPER.writeValueAsString(Map.of(
+                    "csr", Base64.getEncoder().encodeToString(csrDer)));
+        } catch (Exception e) {
+            throw upstream("the certificate request could not be encoded");
+        }
+
+        HttpResponse<String> response = postCertificate(body, accessToken(false));
+        if (response.statusCode() == 401) {
+            // The cached token may have been revoked or rotated server-side;
+            // force a fresh one and try once more before giving up.
+            response = postCertificate(body, accessToken(true));
+        }
+        return parseIssued(response);
+    }
+
+    @Override
+    public synchronized String issuerPem() {
+        if (cachedIssuerPem != null) {
+            return cachedIssuerPem;
+        }
+        HttpRequest request = HttpRequest.newBuilder(issuerEndpoint)
+                .timeout(timeout)
+                .header("Accept", "application/pem-certificate-chain")
+                .GET()
+                .build();
+        HttpResponse<String> response = send(request, "issuer certificate");
+        if (response.statusCode() != 200) {
+            throw upstream("the certificate API returned HTTP " + response.statusCode()
+                    + " for the issuer certificate");
+        }
+        cachedIssuerPem = response.body();
+        return cachedIssuerPem;
+    }
+
+    private HttpResponse<String> postCertificate(String body, String token) {
+        HttpRequest request = HttpRequest.newBuilder(certificatesEndpoint)
+                .timeout(timeout)
+                .header("Authorization", "Bearer " + token)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        return send(request, "certificate issuance");
+    }
+
+    private IssuedCertificate parseIssued(HttpResponse<String> response) {
+        if (response.statusCode() == 201) {
+            try {
+                JsonNode body = Json.MAPPER.readTree(response.body());
+                return new IssuedCertificate(
+                        decodeBase64(body.path("certificate").asText()),
+                        decodeBase64(body.path("chain").asText()));
+            } catch (Exception e) {
+                LOG.warn("Remote certificate API returned an unreadable response detail={}", e.toString());
+                throw upstream("the certificate API returned an unreadable response");
+            }
+        }
+        String detail = errorDetail(response);
+        if (response.statusCode() == 400) {
+            // A rejected CSR is the client's fault: surface it as such so the
+            // ACME client sees a 4xx rather than a retryable server error.
+            throw new AcmeException(400, "badCSR", "the certificate API rejected the CSR: " + detail);
+        }
+        LOG.warn("Remote certificate API returned status={} detail={}", response.statusCode(), detail);
+        throw upstream("the certificate API returned HTTP " + response.statusCode());
+    }
+
+    private synchronized String accessToken(boolean forceRefresh) {
+        if (!forceRefresh && cachedToken != null && Instant.now().isBefore(tokenExpiresAt)) {
+            return cachedToken;
+        }
+        StringBuilder form = new StringBuilder("grant_type=client_credentials");
+        if (scope != null) {
+            form.append("&scope=").append(URLEncoder.encode(scope, StandardCharsets.UTF_8));
+        }
+        HttpRequest request = HttpRequest.newBuilder(tokenEndpoint)
+                .timeout(timeout)
+                .header("Authorization", basicAuth)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(form.toString()))
+                .build();
+        HttpResponse<String> response = send(request, "access token");
+        if (response.statusCode() != 200) {
+            LOG.warn("Token endpoint returned status={} url={}", response.statusCode(), tokenEndpoint);
+            throw upstream("the authorization server returned HTTP " + response.statusCode()
+                    + " for the client credentials grant");
+        }
+        try {
+            JsonNode body = Json.MAPPER.readTree(response.body());
+            String token = body.path("access_token").asText(null);
+            if (token == null || token.isBlank()) {
+                throw upstream("the authorization server response contained no access_token");
+            }
+            long expiresIn = body.path("expires_in").asLong(DEFAULT_TOKEN_TTL_SECONDS);
+            cachedToken = token;
+            tokenExpiresAt = Instant.now().plusSeconds(Math.max(expiresIn - TOKEN_REFRESH_SKEW_SECONDS, 1));
+            return token;
+        } catch (AcmeException e) {
+            throw e;
+        } catch (Exception e) {
+            LOG.warn("Token endpoint response could not be parsed url={} detail={}", tokenEndpoint, e.toString());
+            throw upstream("the authorization server token response could not be parsed");
+        }
+    }
+
+    private HttpResponse<String> send(HttpRequest request, String operation) {
+        try {
+            return http.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw upstream("the " + operation + " request was interrupted");
+        } catch (IOException e) {
+            LOG.warn("Remote certificate API unreachable operation={} detail={}", operation, e.toString());
+            throw upstream("the certificate API is unreachable");
+        }
+    }
+
+    private static String decodeBase64(String value) {
+        return new String(Base64.getMimeDecoder().decode(value.trim()), StandardCharsets.UTF_8);
+    }
+
+    private static String errorDetail(HttpResponse<String> response) {
+        try {
+            JsonNode body = Json.MAPPER.readTree(response.body());
+            JsonNode description = body.path("error_description");
+            if (!description.isMissingNode()) {
+                return description.asText();
+            }
+        } catch (Exception ignored) {
+            // Fall through to a generic detail.
+        }
+        return "no detail provided";
+    }
+
+    // Issuance failed because of the upstream certificate API, not the ACME
+    // client; a 5xx tells the client the request is worth retrying.
+    private static AcmeException upstream(String detail) {
+        return new AcmeException(502, "serverInternal", detail);
+    }
+}

--- a/quick-pki-acme-server/src/test/java/com/elevenware/quickpki/acme/AcmeTestSupport.java
+++ b/quick-pki-acme-server/src/test/java/com/elevenware/quickpki/acme/AcmeTestSupport.java
@@ -1,8 +1,19 @@
 package com.elevenware.quickpki.acme;
 
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.ExtensionsGenerator;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.h2.jdbcx.JdbcDataSource;
 
 import javax.sql.DataSource;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -12,6 +23,21 @@ import java.util.UUID;
 final class AcmeTestSupport {
 
     private AcmeTestSupport() {
+    }
+
+    /** Builds a signed PKCS#10 request carrying a single dNSName SAN, in DER form. */
+    static byte[] csrWithDnsSan(String dnsName) throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+        JcaPKCS10CertificationRequestBuilder builder = new JcaPKCS10CertificationRequestBuilder(
+                new X500Name("CN=" + dnsName), keyPair.getPublic());
+        ExtensionsGenerator extensions = new ExtensionsGenerator();
+        extensions.addExtension(Extension.subjectAlternativeName, false,
+                new GeneralNames(new GeneralName(GeneralName.dNSName, dnsName)));
+        builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extensions.generate());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(keyPair.getPrivate());
+        return builder.build(signer).getEncoded();
     }
 
     static AcmeConfig config() {
@@ -27,7 +53,8 @@ final class AcmeTestSupport {
                 Duration.ofHours(1),
                 Duration.ofMillis(10),
                 1,
-                java.util.List.of());
+                java.util.List.of(),
+                null);
     }
 
     static DataSource dataSource() throws SQLException {

--- a/quick-pki-acme-server/src/test/java/com/elevenware/quickpki/acme/RemoteCertificateIssuerTest.java
+++ b/quick-pki-acme-server/src/test/java/com/elevenware/quickpki/acme/RemoteCertificateIssuerTest.java
@@ -1,0 +1,139 @@
+package com.elevenware.quickpki.acme;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+class RemoteCertificateIssuerTest {
+
+    private static final String CERT_PEM =
+            "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n";
+    private static final String CHAIN_PEM = CERT_PEM
+            + "-----BEGIN CERTIFICATE-----\nroot\n-----END CERTIFICATE-----\n";
+    private static final String ISSUER_PEM =
+            "-----BEGIN CERTIFICATE-----\nroot\n-----END CERTIFICATE-----\n";
+
+    private HttpServer server;
+    private String baseUrl;
+    private final AtomicInteger tokenRequests = new AtomicInteger();
+    private final AtomicInteger issueRequests = new AtomicInteger();
+    private final AtomicReference<String> lastBearer = new AtomicReference<>();
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/token", exchange -> {
+            tokenRequests.incrementAndGet();
+            String auth = exchange.getRequestHeaders().getFirst("Authorization");
+            if (auth == null || !auth.startsWith("Basic ")) {
+                respond(exchange, 401, "{\"error\":\"invalid_client\"}");
+                return;
+            }
+            respond(exchange, 200, "{\"access_token\":\"tok-" + tokenRequests.get()
+                    + "\",\"token_type\":\"Bearer\",\"expires_in\":3600}");
+        });
+        server.createContext("/v1/certificates", exchange -> {
+            issueRequests.incrementAndGet();
+            lastBearer.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            respond(exchange, 201, "{\"id\":\"" + UUID.randomUUID()
+                    + "\",\"certificate\":\"" + base64(CERT_PEM)
+                    + "\",\"chain\":\"" + base64(CHAIN_PEM) + "\"}");
+        });
+        server.createContext("/issuer/root.pem", exchange -> respond(exchange, 200, ISSUER_PEM));
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    @Test
+    void issuesCertificateThroughRemoteApi() throws Exception {
+        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(remoteConfig());
+        byte[] csr = AcmeTestSupport.csrWithDnsSan("example.test");
+
+        CertificateIssuer.IssuedCertificate issued =
+                issuer.issue(csr, List.of(new Identifier("dns", "example.test")));
+
+        assertThat(issued.certificatePem()).isEqualTo(CERT_PEM);
+        assertThat(issued.chainPem()).isEqualTo(CHAIN_PEM);
+        assertThat(lastBearer.get()).startsWith("Bearer tok-");
+        assertThat(issueRequests.get()).isEqualTo(1);
+    }
+
+    @Test
+    void reusesCachedAccessTokenAcrossCalls() throws Exception {
+        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(remoteConfig());
+        byte[] csr = AcmeTestSupport.csrWithDnsSan("example.test");
+        List<Identifier> identifiers = List.of(new Identifier("dns", "example.test"));
+
+        issuer.issue(csr, identifiers);
+        issuer.issue(csr, identifiers);
+
+        assertThat(issueRequests.get()).isEqualTo(2);
+        assertThat(tokenRequests.get()).isEqualTo(1);
+    }
+
+    @Test
+    void rejectsUnvalidatedSanWithoutCallingApi() throws Exception {
+        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(remoteConfig());
+        byte[] csr = AcmeTestSupport.csrWithDnsSan("evil.test");
+
+        AcmeException error = catchThrowableOfType(
+                () -> issuer.issue(csr, List.of(new Identifier("dns", "example.test"))),
+                AcmeException.class);
+
+        assertThat(error).isNotNull();
+        assertThat(error.status()).isEqualTo(400);
+        assertThat(error.type()).isEqualTo("badCSR");
+        assertThat(issueRequests.get()).isZero();
+    }
+
+    @Test
+    void fetchesAndCachesIssuerCertificate() {
+        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(remoteConfig());
+
+        assertThat(issuer.issuerPem()).isEqualTo(ISSUER_PEM);
+        assertThat(issuer.issuerPem()).isEqualTo(ISSUER_PEM);
+    }
+
+    private AcmeConfig.RemoteIssuerConfig remoteConfig() {
+        return new AcmeConfig.RemoteIssuerConfig(
+                baseUrl,
+                baseUrl + "/token",
+                "acme-client",
+                "s3cr3t",
+                "certificates:issue",
+                Duration.ofSeconds(5));
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(bytes);
+        }
+    }
+
+    private static String base64(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## Summary

The ACME server can now optionally be configured to delegate certificate
issuance to a **deployed certificate issuance API** instead of minting
certificates from a locally held CA. This lets a single issuing CA back
multiple ACME front ends.

Issuance is abstracted behind a new `CertificateIssuer` interface with two
implementations, selected at startup from configuration:

- `CertificateAuthorityService` — the existing local CA (default).
- `RemoteCertificateIssuer` — obtains OAuth 2.0 access tokens via the client
  credentials grant, caches them until they near expiry, and forwards CSRs to
  the certificate API for signing.

ACME challenge validation and SAN policy enforcement still happen in the ACME
server regardless of mode: the "only validated identifiers may appear as SANs"
rule was extracted into a shared `CsrValidation` helper so it applies before a
CSR ever reaches the remote API. `POST /admin/ca/rotate` returns 409 in remote
mode, since the issuing CA is owned by the certificate API.

## Configuration

Remote mode is enabled by setting `ACME_CERT_API_URL`. New environment variables:

- `ACME_CERT_API_URL` — base URL of the certificate API (enables remote mode)
- `ACME_CERT_API_TOKEN_URL` — OAuth 2.0 token endpoint (client credentials grant)
- `ACME_CERT_API_CLIENT_ID` / `ACME_CERT_API_CLIENT_SECRET` — confidential client credentials
- `ACME_CERT_API_SCOPE` — optional scope
- `ACME_CERT_API_TIMEOUT_SECONDS` — optional HTTP timeout, default `10`

`ACME_CA_KEY_PASSWORD` is now only required in local CA mode.

## Test plan

- [x] `mvn -pl quick-pki-acme-server -am verify` passes (13 module tests, incl. 4 new)
- [x] New `RemoteCertificateIssuerTest` exercises the remote flow against an
      in-process HTTP server: token acquisition, certificate issuance, token
      caching across calls, SAN rejection before any API call, and issuer
      certificate fetch/cache.
- [ ] Manual end-to-end check against a real deployed certificate API

https://claude.ai/code/session_01ByJc2Ghj3sTUDhAivK7KXi

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByJc2Ghj3sTUDhAivK7KXi)_