### PR TITLE
Add OpenAPI document for the certificate API

### DIFF
--- a/quick-pki-cert-api/README.md
+++ b/quick-pki-cert-api/README.md
@@ -43,6 +43,15 @@ Common:
 | GET    | `/v1/certificates/{id}`  | Bearer      | Fetch a previously issued cert       |
 | GET    | `/issuer/root.pem`       | none        | Download the issuing CA certificate  |
 | GET    | `/healthz`               | none        | Liveness/readiness probe             |
+| GET    | `/openapi.yaml`          | none        | OpenAPI 3.0 description of this API   |
+| GET    | `/docs`                  | none        | Browsable API reference (Redoc)      |
+
+## API documentation
+
+The service describes itself with an OpenAPI 3.0 document, served at
+`/openapi.yaml` with the `servers` URL set to this deployment's external URL.
+A browsable reference rendered with Redoc is available at `/docs`. The source
+document lives at `src/main/resources/openapi.yaml`.
 
 ### Issuing a certificate
 

--- a/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertApiServer.java
+++ b/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertApiServer.java
@@ -7,6 +7,9 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
@@ -31,6 +34,7 @@ final class CertApiServer {
     private final CertApiRepository repository;
     private final CertificateAuthorityService caService;
     private final TokenIntrospector introspector;
+    private final String openApiSpec;
 
     CertApiServer(
             CertApiConfig config,
@@ -41,6 +45,10 @@ final class CertApiServer {
         this.repository = repository;
         this.caService = caService;
         this.introspector = introspector;
+        // The static spec uses a placeholder server URL so the served copy
+        // reflects however this instance is actually reached.
+        this.openApiSpec = loadResource("/openapi.yaml")
+                .replace("__SERVER_URL__", config.externalUrl());
     }
 
     void start() {
@@ -70,6 +78,36 @@ final class CertApiServer {
         routes.get("/issuer/root.pem", ctx -> ctx.contentType("application/pem-certificate-chain")
                 .result(caService.issuerPem()));
         routes.get("/healthz", ctx -> ctx.result("ok"));
+        routes.get("/openapi.yaml", ctx -> ctx.contentType("application/yaml").result(openApiSpec));
+        routes.get("/docs", ctx -> ctx.contentType("text/html").result(DOCS_PAGE));
+    }
+
+    // A self-contained API reference page; pulls Redoc from a CDN and renders
+    // the spec served at /openapi.yaml (relative, so any base path works).
+    private static final String DOCS_PAGE = """
+            <!doctype html>
+            <html>
+            <head>
+              <title>Quick-PKI Certificate API</title>
+              <meta charset="utf-8"/>
+              <meta name="viewport" content="width=device-width, initial-scale=1"/>
+            </head>
+            <body>
+              <redoc spec-url="openapi.yaml"></redoc>
+              <script src="https://cdn.redocly.com/redoc/latest/bundles/redoc.standalone.js"></script>
+            </body>
+            </html>
+            """;
+
+    private static String loadResource(String path) {
+        try (InputStream in = CertApiServer.class.getResourceAsStream(path)) {
+            if (in == null) {
+                throw new IllegalStateException("missing classpath resource " + path);
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException("could not read classpath resource " + path, e);
+        }
     }
 
     // Bearer-token gate for the protected resource. Registered as a pathless

--- a/quick-pki-cert-api/src/main/resources/openapi.yaml
+++ b/quick-pki-cert-api/src/main/resources/openapi.yaml
@@ -1,0 +1,252 @@
+openapi: 3.0.3
+info:
+  title: Quick-PKI Certificate API
+  version: "1.0.0"
+  description: |
+    A RESTful certificate issuance service. A caller submits a base64-encoded
+    PKCS#10 CSR and receives a signed certificate back in the same encoding.
+
+    Routes under `/v1` are an OAuth 2.0 protected resource: every request must
+    present a bearer access token, validated by RFC 7662 token introspection
+    against an externally configured authorization server. Callers obtain their
+    tokens using the client credentials grant. When the service is configured
+    with a required scope, the token must additionally carry that scope.
+
+    The issuer certificate, health, and documentation endpoints are
+    unauthenticated.
+servers:
+  - url: __SERVER_URL__
+    description: This deployment
+
+tags:
+  - name: Certificates
+    description: Issue and retrieve certificates
+  - name: Public
+    description: Unauthenticated endpoints
+
+paths:
+  /v1/certificates:
+    post:
+      tags: [Certificates]
+      summary: Issue a certificate from a CSR
+      description: |
+        Signs the supplied PKCS#10 certificate request with the issuing CA,
+        persists the result, and returns it. The `Location` response header
+        points at the persisted certificate resource.
+      operationId: issueCertificate
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CertificateRequest'
+      responses:
+        '201':
+          description: Certificate issued
+          headers:
+            Location:
+              description: URL of the persisted certificate resource
+              schema:
+                type: string
+                format: uri
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssuedCertificate'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /v1/certificates/{id}:
+    get:
+      tags: [Certificates]
+      summary: Fetch a previously issued certificate
+      operationId: getCertificate
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The certificate's UUID, as returned by the issue call.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: The certificate
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssuedCertificate'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /issuer/root.pem:
+    get:
+      tags: [Public]
+      summary: Download the issuing CA certificate
+      description: Returns the issuing CA's self-signed certificate in PEM form.
+      operationId: getIssuerCertificate
+      security: []
+      responses:
+        '200':
+          description: The issuing CA certificate
+          content:
+            application/pem-certificate-chain:
+              schema:
+                type: string
+              example: |
+                -----BEGIN CERTIFICATE-----
+                MIIB...
+                -----END CERTIFICATE-----
+
+  /healthz:
+    get:
+      tags: [Public]
+      summary: Liveness/readiness probe
+      operationId: healthCheck
+      security: []
+      responses:
+        '200':
+          description: The service is up
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ok
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: OAuth 2.0 access token
+      description: |
+        An OAuth 2.0 bearer access token obtained via the client credentials
+        grant from the authorization server this service is configured to
+        trust.
+
+  schemas:
+    CertificateRequest:
+      type: object
+      required: [csr]
+      properties:
+        csr:
+          type: string
+          format: byte
+          description: |
+            A base64 encoding of a PKCS#10 certificate request. The decoded
+            bytes may be either raw DER or a PEM-wrapped request.
+          example: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K
+
+    IssuedCertificate:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Stable identifier of the persisted certificate.
+        serialNumber:
+          type: string
+          description: The certificate serial number, hex-encoded.
+          example: 1a2b3c4d
+        subject:
+          type: string
+          description: The certificate subject distinguished name.
+          example: CN=service.example.com
+        certificate:
+          type: string
+          format: byte
+          description: The signed leaf certificate, as base64-encoded PEM.
+        chain:
+          type: string
+          format: byte
+          description: The certificate chain, leaf-first, as base64-encoded PEM.
+        notBefore:
+          type: string
+          format: date-time
+          description: Start of the certificate validity window.
+        notAfter:
+          type: string
+          format: date-time
+          description: End of the certificate validity window.
+        issuedAt:
+          type: string
+          format: date-time
+          description: When the service issued the certificate.
+
+    Error:
+      type: object
+      description: |
+        Error responses follow OAuth 2.0 conventions; for 401 and 403 the
+        `error` code is also echoed in a `WWW-Authenticate` header.
+      properties:
+        error:
+          type: string
+          description: Machine-readable error code.
+          example: invalid_request
+        error_description:
+          type: string
+          description: Human-readable explanation.
+        status:
+          type: integer
+          description: The HTTP status code.
+      required: [error, error_description, status]
+
+  responses:
+    BadRequest:
+      description: |
+        The request body or CSR was malformed. The `error` code is
+        `invalid_request` for a bad body, or `bad_csr` for a CSR that could
+        not be parsed as a PKCS#10 request.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: The bearer token is missing, empty, or not active.
+      headers:
+        WWW-Authenticate:
+          schema:
+            type: string
+          description: 'Bearer challenge, e.g. Bearer error="invalid_token", ...'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Forbidden:
+      description: The token is active but lacks the required scope.
+      headers:
+        WWW-Authenticate:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: No certificate exists with the given id.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    ServerError:
+      description: An unexpected error occurred while serving the request.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'

--- a/quick-pki-cert-api/src/test/java/com/elevenware/quickpki/certapi/CertApiServerTest.java
+++ b/quick-pki-cert-api/src/test/java/com/elevenware/quickpki/certapi/CertApiServerTest.java
@@ -133,6 +133,31 @@ class CertApiServerTest {
         assertThat(response.body()).contains("BEGIN CERTIFICATE");
     }
 
+    @Test
+    void servesTheOpenApiDocumentWithoutAuthentication() throws Exception {
+        start(null);
+
+        HttpResponse<String> response = get("/openapi.yaml", null);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.headers().firstValue("Content-Type")).get().asString()
+                .startsWith("application/yaml");
+        assertThat(response.body()).contains("openapi: 3.0.3");
+        assertThat(response.body()).contains("/v1/certificates");
+        // The placeholder is substituted with the configured external URL.
+        assertThat(response.body()).doesNotContain("__SERVER_URL__");
+    }
+
+    @Test
+    void servesTheApiReferencePage() throws Exception {
+        start(null);
+
+        HttpResponse<String> response = get("/docs", null);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).contains("spec-url=\"openapi.yaml\"");
+    }
+
     private void start(String requiredScope) throws Exception {
         DataSource dataSource = CertApiTestSupport.dataSource();
         String introspectionUrl = "http://localhost:" + authServer.port() + "/introspect";


### PR DESCRIPTION
## Summary

- Add an OpenAPI 3.0 document (`quick-pki-cert-api/src/main/resources/openapi.yaml`) describing the cert-api HTTP surface: certificate issue/fetch, the issuer cert, and health endpoints, plus the OAuth 2.0 bearer security scheme and the shared JSON error model.
- Serve the spec from the service itself at `GET /openapi.yaml` and a Redoc-rendered reference at `GET /docs`. Both are unauthenticated (they sit outside the `/v1` bearer gate).
- The served spec has its `servers` URL substituted with the deployment's configured external URL, so the copy a caller fetches always reflects how the instance is reached.
- Update the README endpoints table and add an API documentation section.

## Test plan

- [x] `mvn -pl quick-pki-cert-api -am test` — all 16 cert-api tests pass
- [x] New tests cover that `/openapi.yaml` is served unauthenticated with the placeholder substituted, and that `/docs` renders the reference page

https://claude.ai/code/session_016DiygrGDisUie7UWbUMg5Y

---
_Generated by [Claude Code](https://claude.ai/code/session_016DiygrGDisUie7UWbUMg5Y)_