### PR TITLE
Split health endpoint into k8s liveness and readiness probes

### DIFF
--- a/quick-pki-cert-api/README.md
+++ b/quick-pki-cert-api/README.md
@@ -42,9 +42,25 @@ Common:
 | POST   | `/v1/certificates`       | Bearer      | Issue a certificate from a CSR       |
 | GET    | `/v1/certificates/{id}`  | Bearer      | Fetch a previously issued cert       |
 | GET    | `/issuer/root.pem`       | none        | Download the issuing CA certificate  |
-| GET    | `/healthz`               | none        | Liveness/readiness probe             |
+| GET    | `/healthz`               | none        | Liveness probe — process is up       |
+| GET    | `/readyz`                | none        | Readiness probe — database reachable |
 | GET    | `/openapi.yaml`          | none        | OpenAPI 3.0 description of this API   |
 | GET    | `/docs`                  | none        | Browsable API reference (Redoc)      |
+
+## Health checks
+
+Two unauthenticated endpoints support Kubernetes probes, both returning a JSON
+`{"status": ...}` body:
+
+- `GET /healthz` — liveness. Confirms only that the process is up and serving
+  HTTP. It touches no dependencies, so a database outage never restarts pods.
+- `GET /readyz` — readiness. Confirms the service can do work by validating a
+  pooled database connection. Returns `200` when the database is reachable and
+  `503` otherwise, so an affected pod is pulled from the Service's endpoints
+  until it recovers — without a restart.
+
+The manifests in `k8s/` wire `/healthz` to both the startup and liveness
+probes and `/readyz` to the readiness probe.
 
 ## API documentation
 

--- a/quick-pki-cert-api/k8s/quick-pki-cert-api.yaml
+++ b/quick-pki-cert-api/k8s/quick-pki-cert-api.yaml
@@ -47,14 +47,35 @@ spec:
                 name: quick-pki-cert-api
             - secretRef:
                 name: quick-pki-cert-api
-          readinessProbe:
+          # Startup: covers the slow first boot (Liquibase migration and, on a
+          # fresh database, issuing CA generation). Gives up to 60s before the
+          # liveness probe takes over, so a slow start is never mistaken for a
+          # hung process.
+          startupProbe:
             httpGet:
               path: /healthz
               port: 8080
+            periodSeconds: 5
+            failureThreshold: 12
+          # Liveness: is the process still up? Dependency-free, so a database
+          # outage never restarts the pod.
           livenessProbe:
             httpGet:
               path: /healthz
               port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          # Readiness: can the pod serve traffic? Checks database reachability,
+          # so a pod with a broken database is removed from the Service's
+          # endpoints until it recovers — without a restart.
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
 ---
 apiVersion: v1
 kind: Service

--- a/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertApiServer.java
+++ b/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertApiServer.java
@@ -7,11 +7,14 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.sql.DataSource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.LinkedHashMap;
@@ -30,21 +33,29 @@ final class CertApiServer {
 
     private static final Logger LOG = LoggerFactory.getLogger(CertApiServer.class);
 
+    // Bound on how long the readiness probe waits to validate a pooled
+    // connection: short enough that a stalled database fails the probe
+    // promptly rather than letting Kubernetes' own probe timeout fire.
+    private static final int READINESS_TIMEOUT_SECONDS = 2;
+
     private final CertApiConfig config;
     private final CertApiRepository repository;
     private final CertificateAuthorityService caService;
     private final TokenIntrospector introspector;
+    private final DataSource dataSource;
     private final String openApiSpec;
 
     CertApiServer(
             CertApiConfig config,
             CertApiRepository repository,
             CertificateAuthorityService caService,
-            TokenIntrospector introspector) {
+            TokenIntrospector introspector,
+            DataSource dataSource) {
         this.config = config;
         this.repository = repository;
         this.caService = caService;
         this.introspector = introspector;
+        this.dataSource = dataSource;
         // The static spec uses a placeholder server URL so the served copy
         // reflects however this instance is actually reached.
         this.openApiSpec = loadResource("/openapi.yaml")
@@ -77,9 +88,33 @@ final class CertApiServer {
         routes.get("/v1/certificates/{id}", this::getCertificate);
         routes.get("/issuer/root.pem", ctx -> ctx.contentType("application/pem-certificate-chain")
                 .result(caService.issuerPem()));
-        routes.get("/healthz", ctx -> ctx.result("ok"));
+        routes.get("/healthz", this::liveness);
+        routes.get("/readyz", this::readiness);
         routes.get("/openapi.yaml", ctx -> ctx.contentType("application/yaml").result(openApiSpec));
         routes.get("/docs", ctx -> ctx.contentType("text/html").result(DOCS_PAGE));
+    }
+
+    // Liveness probe: confirms only that the process is up and can serve HTTP.
+    // It deliberately touches no dependencies, so a transient database outage
+    // sheds traffic via the readiness probe instead of restarting every pod.
+    private void liveness(Context ctx) {
+        ctx.json(Map.of("status", "alive"));
+    }
+
+    // Readiness probe: confirms the service can actually do work, which means
+    // its database is reachable. A failure here removes the pod from the
+    // Service's endpoints until the dependency recovers — no restart.
+    private void readiness(Context ctx) {
+        try (Connection connection = dataSource.getConnection()) {
+            if (connection.isValid(READINESS_TIMEOUT_SECONDS)) {
+                ctx.json(Map.of("status", "ready"));
+                return;
+            }
+            LOG.warn("Readiness check failed: database connection is not valid");
+        } catch (SQLException e) {
+            LOG.warn("Readiness check failed: database is unreachable", e);
+        }
+        ctx.status(503).json(Map.of("status", "unavailable", "detail", "database unreachable"));
     }
 
     // A self-contained API reference page; pulls Redoc from a CDN and renders
@@ -235,6 +270,12 @@ final class CertApiServer {
     }
 
     private void logRequest(Context ctx) {
+        // Kubernetes polls the probes every few seconds; logging each hit
+        // would bury genuine request traffic, so leave them out.
+        String path = ctx.path();
+        if (path.equals("/healthz") || path.equals("/readyz")) {
+            return;
+        }
         Long startedAtNanos = ctx.attribute("startedAtNanos");
         long durationMs = startedAtNanos == null ? -1L : (System.nanoTime() - startedAtNanos) / 1_000_000L;
         LOG.info("request method={} path={} status={} durationMs={} remote={}",

--- a/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/Main.java
+++ b/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/Main.java
@@ -27,7 +27,8 @@ public final class Main {
         CertificateAuthorityService caService = CertificateAuthorityService.loadOrCreate(config, repository);
         TokenIntrospector introspector = TokenIntrospector.fromConfig(config);
 
-        CertApiServer server = new CertApiServer(config, repository, caService, introspector);
+        CertApiServer server = new CertApiServer(
+                config, repository, caService, introspector, database.dataSource());
         server.start();
     }
 }

--- a/quick-pki-cert-api/src/main/resources/openapi.yaml
+++ b/quick-pki-cert-api/src/main/resources/openapi.yaml
@@ -117,17 +117,49 @@ paths:
   /healthz:
     get:
       tags: [Public]
-      summary: Liveness/readiness probe
-      operationId: healthCheck
+      summary: Liveness probe
+      description: >
+        Confirms the process is up and serving HTTP. Touches no dependencies,
+        so it is not affected by a database outage.
+      operationId: liveness
       security: []
       responses:
         '200':
-          description: The service is up
+          description: The process is alive
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                example: ok
+                $ref: '#/components/schemas/HealthStatus'
+              example:
+                status: alive
+
+  /readyz:
+    get:
+      tags: [Public]
+      summary: Readiness probe
+      description: >
+        Confirms the service can serve requests by checking that its database
+        is reachable.
+      operationId: readiness
+      security: []
+      responses:
+        '200':
+          description: The service is ready to serve traffic
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+              example:
+                status: ready
+        '503':
+          description: A dependency is unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+              example:
+                status: unavailable
+                detail: database unreachable
 
 components:
   securitySchemes:
@@ -141,6 +173,21 @@ components:
         trust.
 
   schemas:
+    HealthStatus:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          description: >
+            The probe outcome: `alive` and `ready` accompany a 200; `unavailable`
+            accompanies a 503.
+          enum: [alive, ready, unavailable]
+        detail:
+          type: string
+          description: Human-readable explanation, present when a probe fails.
+          example: database unreachable
+
     CertificateRequest:
       type: object
       required: [csr]

--- a/quick-pki-cert-api/src/test/java/com/elevenware/quickpki/certapi/CertApiServerTest.java
+++ b/quick-pki-cert-api/src/test/java/com/elevenware/quickpki/certapi/CertApiServerTest.java
@@ -7,13 +7,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
+import java.io.PrintWriter;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.Base64;
 import java.util.Map;
+import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -149,6 +153,41 @@ class CertApiServerTest {
     }
 
     @Test
+    void reportsLivenessWithoutAuthentication() throws Exception {
+        start(null);
+
+        HttpResponse<String> response = get("/healthz", null);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(Json.MAPPER.readTree(response.body()).get("status").asText()).isEqualTo("alive");
+    }
+
+    @Test
+    void reportsReadinessWhenTheDatabaseIsReachable() throws Exception {
+        start(null);
+
+        HttpResponse<String> response = get("/readyz", null);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(Json.MAPPER.readTree(response.body()).get("status").asText()).isEqualTo("ready");
+    }
+
+    @Test
+    void reportsNotReadyWhenTheDatabaseIsUnreachable() throws Exception {
+        // The service starts against a healthy database, then loses it: the
+        // liveness probe stays green while readiness flips to 503.
+        ToggleableDataSource dataSource = new ToggleableDataSource(CertApiTestSupport.dataSource());
+        start(null, dataSource);
+        dataSource.fail();
+
+        HttpResponse<String> readiness = get("/readyz", null);
+        assertThat(readiness.statusCode()).isEqualTo(503);
+        assertThat(Json.MAPPER.readTree(readiness.body()).get("status").asText()).isEqualTo("unavailable");
+
+        assertThat(get("/healthz", null).statusCode()).isEqualTo(200);
+    }
+
+    @Test
     void servesTheApiReferencePage() throws Exception {
         start(null);
 
@@ -159,13 +198,16 @@ class CertApiServerTest {
     }
 
     private void start(String requiredScope) throws Exception {
-        DataSource dataSource = CertApiTestSupport.dataSource();
+        start(requiredScope, CertApiTestSupport.dataSource());
+    }
+
+    private void start(String requiredScope, DataSource dataSource) throws Exception {
         String introspectionUrl = "http://localhost:" + authServer.port() + "/introspect";
         CertApiConfig config = CertApiTestSupport.config(introspectionUrl, requiredScope);
         CertApiRepository repository = new CertApiRepository(dataSource);
         CertificateAuthorityService caService = CertificateAuthorityService.loadOrCreate(config, repository);
         TokenIntrospector introspector = TokenIntrospector.fromConfig(config);
-        api = new CertApiServer(config, repository, caService, introspector).app().start(0);
+        api = new CertApiServer(config, repository, caService, introspector, dataSource).app().start(0);
     }
 
     private URI uri(String path) {
@@ -188,5 +230,72 @@ class CertApiServerTest {
             request.header("Authorization", "Bearer " + token);
         }
         return http.send(request.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    /**
+     * A {@link DataSource} that delegates normally until {@link #fail()} is
+     * called, after which every {@code getConnection} throws — standing in for
+     * a database that has become unreachable after the service started.
+     */
+    private static final class ToggleableDataSource implements DataSource {
+
+        private final DataSource delegate;
+        private volatile boolean failing;
+
+        ToggleableDataSource(DataSource delegate) {
+            this.delegate = delegate;
+        }
+
+        void fail() {
+            this.failing = true;
+        }
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            if (failing) {
+                throw new SQLException("database is unreachable");
+            }
+            return delegate.getConnection();
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            return getConnection();
+        }
+
+        @Override
+        public PrintWriter getLogWriter() throws SQLException {
+            return delegate.getLogWriter();
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) throws SQLException {
+            delegate.setLogWriter(out);
+        }
+
+        @Override
+        public void setLoginTimeout(int seconds) throws SQLException {
+            delegate.setLoginTimeout(seconds);
+        }
+
+        @Override
+        public int getLoginTimeout() throws SQLException {
+            return delegate.getLoginTimeout();
+        }
+
+        @Override
+        public Logger getParentLogger() {
+            return Logger.getGlobal();
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            return delegate.unwrap(iface);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            return delegate.isWrapperFor(iface);
+        }
     }
 }


### PR DESCRIPTION
The single /healthz endpoint always returned "ok" and was wired to both the liveness and readiness probes, so a database outage that left pods unable to serve traffic would still pass readiness — and a database blip risked restarting every pod.

Split it into two endpoints:

- GET /healthz — liveness. Dependency-free; confirms only that the process is up and serving HTTP, so a database outage never restarts pods. Now returns JSON {"status":"alive"}.
- GET /readyz — readiness. Validates a pooled database connection; returns 200 when reachable and 503 otherwise, so an affected pod is removed from the Service's endpoints without a restart.

The k8s manifest wires /healthz to liveness and a new startup probe (absorbing the slow first boot: Liquibase migration and issuing-CA generation) and /readyz to readiness, with probe tuning on each. Both probe paths are excluded from request logging.

OpenAPI and README updated to match; the spec previously claimed /healthz returned text/plain "ok".