### PR TITLE
Add selectable certificate profiles (Open Finance Brasil BRCAC/BRSEAL)

### DIFF
--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/AcmeConfig.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/AcmeConfig.java
@@ -1,5 +1,7 @@
 package com.elevenware.quickpki.acme;
 
+import com.elevenware.quickpki.CertificateProfile;
+
 import java.net.URI;
 import java.time.Duration;
 import java.util.Arrays;
@@ -18,7 +20,8 @@ record AcmeConfig(
         Duration challengeTimeout,
         int challengeAttempts,
         List<String> dnsServers,
-        RemoteIssuerConfig remoteIssuer
+        RemoteIssuerConfig remoteIssuer,
+        CertificateProfile certificateProfile
 ) {
 
     /**
@@ -68,7 +71,10 @@ record AcmeConfig(
                 Duration.ofSeconds(intEnv("ACME_CHALLENGE_TIMEOUT_SECONDS", 5)),
                 intEnv("ACME_CHALLENGE_ATTEMPTS", 3),
                 csvEnv("ACME_DNS_SERVERS"),
-                remoteIssuer
+                remoteIssuer,
+                // Defaults to TLS_SERVER: ACME issues domain-validated TLS
+                // server certificates, so serverAuth is the right shape.
+                CertificateProfile.fromName(env("ACME_CERTIFICATE_PROFILE", "TLS_SERVER"))
         );
     }
 

--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/CertificateAuthorityService.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/CertificateAuthorityService.java
@@ -2,7 +2,6 @@ package com.elevenware.quickpki.acme;
 
 import com.elevenware.quickpki.CertInfo;
 import com.elevenware.quickpki.CertificateBundle;
-import com.elevenware.quickpki.ExtendedKeyUsageId;
 import com.elevenware.quickpki.IssuerInfo;
 import com.elevenware.quickpki.QuickPki;
 import com.elevenware.quickpki.SubjectName;
@@ -68,7 +67,7 @@ final class CertificateAuthorityService implements CertificateIssuer {
                     .subjectName(SubjectName.builder().commonName(validated.commonName()).build())
                     .validFrom(now.minus(5, ChronoUnit.MINUTES))
                     .validUntil(now.plus(config.certificateLifetime()))
-                    .extendedKeyUsage(ExtendedKeyUsageId.SERVER_AUTH);
+                    .profile(config.certificateProfile());
             for (String dns : validated.dnsNames()) {
                 cert.dnsName(dns);
             }

--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/Main.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/Main.java
@@ -12,20 +12,21 @@ public final class Main {
 
     public static void main(String[] args) throws Exception {
         AcmeConfig config = AcmeConfig.fromEnv();
-        LOG.info("Starting Quick-PKI ACME server port={} externalUrl={} databaseUrl={} dnsServers={} certificateDays={} authzHours={} issuance={}",
+        LOG.info("Starting Quick-PKI ACME server port={} externalUrl={} databaseUrl={} dnsServers={} certificateDays={} authzHours={} issuance={} profile={}",
                 config.port(),
                 config.externalUrl(),
                 config.databaseUrl(),
                 config.dnsServers(),
                 config.certificateLifetime().toDays(),
                 config.authzLifetime().toHours(),
-                config.remoteIssuer() == null ? "local-ca" : "remote-api");
+                config.remoteIssuer() == null ? "local-ca" : "remote-api",
+                config.certificateProfile());
         Database database = Database.open(config);
         database.migrate();
 
         AcmeRepository repository = new AcmeRepository(database.dataSource());
         CertificateIssuer certificateIssuer = config.remoteIssuer() != null
-                ? RemoteCertificateIssuer.fromConfig(config.remoteIssuer())
+                ? RemoteCertificateIssuer.fromConfig(config.remoteIssuer(), config.certificateProfile())
                 : CertificateAuthorityService.loadOrCreate(config, repository);
         NonceService nonceService = new NonceService();
         AcmeJwsService jwsService = new AcmeJwsService(repository, nonceService);

--- a/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/RemoteCertificateIssuer.java
+++ b/quick-pki-acme-server/src/main/java/com/elevenware/quickpki/acme/RemoteCertificateIssuer.java
@@ -1,5 +1,6 @@
 package com.elevenware.quickpki.acme;
 
+import com.elevenware.quickpki.CertificateProfile;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.slf4j.Logger;
@@ -47,17 +48,19 @@ final class RemoteCertificateIssuer implements CertificateIssuer {
     private final String basicAuth;
     private final Duration timeout;
     private final HttpClient http;
+    private final CertificateProfile profile;
 
     private String cachedToken;
     private Instant tokenExpiresAt = Instant.EPOCH;
     private String cachedIssuerPem;
 
-    private RemoteCertificateIssuer(AcmeConfig.RemoteIssuerConfig config) {
+    private RemoteCertificateIssuer(AcmeConfig.RemoteIssuerConfig config, CertificateProfile profile) {
         this.certificatesEndpoint = URI.create(config.apiUrl() + "/v1/certificates");
         this.issuerEndpoint = URI.create(config.apiUrl() + "/issuer/root.pem");
         this.tokenEndpoint = URI.create(config.tokenUrl());
         this.scope = config.scope();
         this.timeout = config.timeout();
+        this.profile = profile;
         this.basicAuth = "Basic " + Base64.getEncoder().encodeToString(
                 (config.clientId() + ":" + config.clientSecret()).getBytes(StandardCharsets.UTF_8));
         this.http = HttpClient.newBuilder()
@@ -65,14 +68,15 @@ final class RemoteCertificateIssuer implements CertificateIssuer {
                 .build();
     }
 
-    static RemoteCertificateIssuer fromConfig(AcmeConfig.RemoteIssuerConfig config) {
+    static RemoteCertificateIssuer fromConfig(AcmeConfig.RemoteIssuerConfig config,
+                                              CertificateProfile profile) {
         // CSR parsing in CsrValidation relies on BouncyCastle; the local CA
         // registers it, but in remote mode that code path never runs.
         Security.addProvider(new BouncyCastleProvider());
-        LOG.info("ACME issuance delegated to remote certificate API url={} tokenUrl={} clientId={} scope={}",
+        LOG.info("ACME issuance delegated to remote certificate API url={} tokenUrl={} clientId={} scope={} profile={}",
                 config.apiUrl(), config.tokenUrl(), config.clientId(),
-                config.scope() == null ? "(none)" : config.scope());
-        return new RemoteCertificateIssuer(config);
+                config.scope() == null ? "(none)" : config.scope(), profile);
+        return new RemoteCertificateIssuer(config, profile);
     }
 
     @Override
@@ -84,7 +88,8 @@ final class RemoteCertificateIssuer implements CertificateIssuer {
         String body;
         try {
             body = Json.MAPPER.writeValueAsString(Map.of(
-                    "csr", Base64.getEncoder().encodeToString(csrDer)));
+                    "csr", Base64.getEncoder().encodeToString(csrDer),
+                    "profile", profile.name()));
         } catch (Exception e) {
             throw upstream("the certificate request could not be encoded");
         }

--- a/quick-pki-acme-server/src/test/java/com/elevenware/quickpki/acme/AcmeTestSupport.java
+++ b/quick-pki-acme-server/src/test/java/com/elevenware/quickpki/acme/AcmeTestSupport.java
@@ -54,7 +54,8 @@ final class AcmeTestSupport {
                 Duration.ofMillis(10),
                 1,
                 java.util.List.of(),
-                null);
+                null,
+                com.elevenware.quickpki.CertificateProfile.TLS_SERVER);
     }
 
     static DataSource dataSource() throws SQLException {

--- a/quick-pki-acme-server/src/test/java/com/elevenware/quickpki/acme/RemoteCertificateIssuerTest.java
+++ b/quick-pki-acme-server/src/test/java/com/elevenware/quickpki/acme/RemoteCertificateIssuerTest.java
@@ -34,6 +34,7 @@ class RemoteCertificateIssuerTest {
     private final AtomicInteger tokenRequests = new AtomicInteger();
     private final AtomicInteger issueRequests = new AtomicInteger();
     private final AtomicReference<String> lastBearer = new AtomicReference<>();
+    private final AtomicReference<String> lastIssueBody = new AtomicReference<>();
 
     @BeforeEach
     void startServer() throws IOException {
@@ -51,6 +52,7 @@ class RemoteCertificateIssuerTest {
         server.createContext("/v1/certificates", exchange -> {
             issueRequests.incrementAndGet();
             lastBearer.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            lastIssueBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
             respond(exchange, 201, "{\"id\":\"" + UUID.randomUUID()
                     + "\",\"certificate\":\"" + base64(CERT_PEM)
                     + "\",\"chain\":\"" + base64(CHAIN_PEM) + "\"}");
@@ -67,7 +69,7 @@ class RemoteCertificateIssuerTest {
 
     @Test
     void issuesCertificateThroughRemoteApi() throws Exception {
-        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(remoteConfig());
+        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(remoteConfig(), com.elevenware.quickpki.CertificateProfile.TLS_SERVER);
         byte[] csr = AcmeTestSupport.csrWithDnsSan("example.test");
 
         CertificateIssuer.IssuedCertificate issued =
@@ -80,8 +82,19 @@ class RemoteCertificateIssuerTest {
     }
 
     @Test
+    void sendsConfiguredCertificateProfileToRemoteApi() throws Exception {
+        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(
+                remoteConfig(), com.elevenware.quickpki.CertificateProfile.BRCAC);
+        byte[] csr = AcmeTestSupport.csrWithDnsSan("example.test");
+
+        issuer.issue(csr, List.of(new Identifier("dns", "example.test")));
+
+        assertThat(lastIssueBody.get()).contains("\"profile\":\"BRCAC\"");
+    }
+
+    @Test
     void reusesCachedAccessTokenAcrossCalls() throws Exception {
-        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(remoteConfig());
+        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(remoteConfig(), com.elevenware.quickpki.CertificateProfile.TLS_SERVER);
         byte[] csr = AcmeTestSupport.csrWithDnsSan("example.test");
         List<Identifier> identifiers = List.of(new Identifier("dns", "example.test"));
 
@@ -94,7 +107,7 @@ class RemoteCertificateIssuerTest {
 
     @Test
     void rejectsUnvalidatedSanWithoutCallingApi() throws Exception {
-        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(remoteConfig());
+        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(remoteConfig(), com.elevenware.quickpki.CertificateProfile.TLS_SERVER);
         byte[] csr = AcmeTestSupport.csrWithDnsSan("evil.test");
 
         AcmeException error = catchThrowableOfType(
@@ -109,7 +122,7 @@ class RemoteCertificateIssuerTest {
 
     @Test
     void fetchesAndCachesIssuerCertificate() {
-        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(remoteConfig());
+        RemoteCertificateIssuer issuer = RemoteCertificateIssuer.fromConfig(remoteConfig(), com.elevenware.quickpki.CertificateProfile.TLS_SERVER);
 
         assertThat(issuer.issuerPem()).isEqualTo(ISSUER_PEM);
         assertThat(issuer.issuerPem()).isEqualTo(ISSUER_PEM);

--- a/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertApiModels.java
+++ b/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertApiModels.java
@@ -36,6 +36,12 @@ record IssuedCertificate(
 ) {
 }
 
-/** Inbound JSON request body for {@code POST /v1/certificates}. */
-record CertificateRequest(String csr) {
+/**
+ * Inbound JSON request body for {@code POST /v1/certificates}.
+ *
+ * @param csr     a base64-encoded PKCS#10 certificate request
+ * @param profile the certificate profile name to issue under (eg. {@code
+ *                BRCAC}); optional, {@code null} means the DEFAULT profile
+ */
+record CertificateRequest(String csr, String profile) {
 }

--- a/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertApiServer.java
+++ b/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertApiServer.java
@@ -1,5 +1,6 @@
 package com.elevenware.quickpki.certapi;
 
+import com.elevenware.quickpki.CertificateProfile;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 import io.javalin.router.JavalinDefaultRoutingApi;
@@ -177,7 +178,8 @@ final class CertApiServer {
     private void issueCertificate(Context ctx) {
         CertificateRequest request = parseRequest(ctx);
         PKCS10CertificationRequest csr = Csrs.parse(request.csr());
-        CertificateAuthorityService.Issued issued = caService.issue(csr);
+        CertificateProfile profile = resolveProfile(request.profile());
+        CertificateAuthorityService.Issued issued = caService.issue(csr, profile);
 
         X509Certificate certificate = issued.certificate();
         UUID id = UUID.randomUUID();
@@ -225,6 +227,16 @@ final class CertApiServer {
 
     private static String base64(String pem) {
         return Base64.getEncoder().encodeToString(pem.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Maps the optional request 'profile' field onto a CertificateProfile,
+    // turning an unknown name into a 400 rather than a 500.
+    private static CertificateProfile resolveProfile(String name) {
+        try {
+            return CertificateProfile.fromName(name);
+        } catch (IllegalArgumentException e) {
+            throw new CertApiException(400, "invalid_request", e.getMessage());
+        }
     }
 
     private CertificateRequest parseRequest(Context ctx) {

--- a/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertificateAuthorityService.java
+++ b/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertificateAuthorityService.java
@@ -1,6 +1,8 @@
 package com.elevenware.quickpki.certapi;
 
+import com.elevenware.quickpki.CertInfo;
 import com.elevenware.quickpki.CertificateBundle;
+import com.elevenware.quickpki.CertificateProfile;
 import com.elevenware.quickpki.IssuerInfo;
 import com.elevenware.quickpki.QuickPki;
 import com.elevenware.quickpki.QuickPkiException;
@@ -48,13 +50,16 @@ final class CertificateAuthorityService {
     }
 
     /**
-     * Signs a leaf certificate from {@code csr}. The CSR's self-signature is
-     * verified before anything is signed; subject DN and subjectAltName entries
-     * are copied from the CSR, and validity defaults to the configured lifetime.
+     * Signs a leaf certificate from {@code csr} under {@code profile}. The
+     * CSR's self-signature is verified before anything is signed; subject DN
+     * and subjectAltName entries are copied from the CSR, and validity defaults
+     * to the configured lifetime. The profile supplies the leaf's KeyUsage /
+     * ExtendedKeyUsage shape.
      */
-    Issued issue(PKCS10CertificationRequest csr) {
+    Issued issue(PKCS10CertificationRequest csr, CertificateProfile profile) {
         try {
-            CertificateBundle bundle = pki.issueCertificate(csr);
+            CertificateBundle bundle = pki.issueCertificate(csr,
+                    CertInfo.fromCsr(csr).profile(profile).build());
             return new Issued(
                     bundle.getCertificate(),
                     bundle.toCertificatePem(),

--- a/quick-pki-cert-api/src/main/resources/openapi.yaml
+++ b/quick-pki-cert-api/src/main/resources/openapi.yaml
@@ -199,6 +199,16 @@ components:
             A base64 encoding of a PKCS#10 certificate request. The decoded
             bytes may be either raw DER or a PEM-wrapped request.
           example: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K
+        profile:
+          type: string
+          enum: [DEFAULT, TLS_SERVER, TLS_CLIENT, BRCAC, BRSEAL]
+          default: DEFAULT
+          description: |
+            The certificate profile to issue under. The profile fixes the
+            leaf's KeyUsage and ExtendedKeyUsage. `BRCAC` and `BRSEAL` are the
+            Open Finance Brasil transport and signing certificate profiles.
+            Omitted or `DEFAULT` issues a general-purpose TLS leaf.
+          example: BRCAC
 
     IssuedCertificate:
       type: object

--- a/quick-pki-cert-api/src/test/java/com/elevenware/quickpki/certapi/CertApiServerTest.java
+++ b/quick-pki-cert-api/src/test/java/com/elevenware/quickpki/certapi/CertApiServerTest.java
@@ -7,12 +7,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
+import java.io.ByteArrayInputStream;
 import java.io.PrintWriter;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Base64;
@@ -76,6 +79,40 @@ class CertApiServerTest {
         assertThat(fetched.statusCode()).isEqualTo(200);
         assertThat(Json.MAPPER.readTree(fetched.body()).get("serialNumber").asText())
                 .isEqualTo(body.get("serialNumber").asText());
+    }
+
+    @Test
+    void issuesACertificateUnderTheRequestedProfile() throws Exception {
+        start("certificates:issue");
+        String csr = CertApiTestSupport.base64Csr("seal.example.com");
+
+        HttpResponse<String> response = post("/v1/certificates", "active-token",
+                "{\"csr\":\"" + csr + "\",\"profile\":\"BRSEAL\"}");
+
+        assertThat(response.statusCode()).isEqualTo(201);
+        X509Certificate cert = parseCertificate(Json.MAPPER.readTree(response.body()));
+        // BRSEAL: digitalSignature + nonRepudiation, and no EKU extension.
+        assertThat(cert.getKeyUsage()[0]).as("digitalSignature").isTrue();
+        assertThat(cert.getKeyUsage()[1]).as("nonRepudiation").isTrue();
+        assertThat(cert.getExtendedKeyUsage()).as("BRSEAL carries no EKU").isNull();
+    }
+
+    @Test
+    void rejectsAnUnknownProfile() throws Exception {
+        start("certificates:issue");
+        String csr = CertApiTestSupport.base64Csr("service.example.com");
+
+        HttpResponse<String> response = post("/v1/certificates", "active-token",
+                "{\"csr\":\"" + csr + "\",\"profile\":\"NONSENSE\"}");
+
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(Json.MAPPER.readTree(response.body()).get("error").asText()).isEqualTo("invalid_request");
+    }
+
+    private static X509Certificate parseCertificate(JsonNode body) throws Exception {
+        byte[] pem = Base64.getDecoder().decode(body.get("certificate").asText());
+        return (X509Certificate) CertificateFactory.getInstance("X.509")
+                .generateCertificate(new ByteArrayInputStream(pem));
     }
 
     @Test

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertInfo.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertInfo.java
@@ -19,6 +19,7 @@ public final class CertInfo {
     private final List<String> ipAddresses;
     private final Set<KeyUsageBit> keyUsages;
     private final Set<ExtendedKeyUsageId> extendedKeyUsages;
+    private final CertificateProfile profile;
 
     private CertInfo(Builder builder) {
         this.subjectName = builder.subjectName;
@@ -26,6 +27,9 @@ public final class CertInfo {
         this.validUntil = builder.validUntil;
         this.dnsNames = List.copyOf(builder.dnsNames);
         this.ipAddresses = List.copyOf(builder.ipAddresses);
+        // Never null: a CertInfo without an explicit profile behaves exactly
+        // as QuickPki did before profiles existed.
+        this.profile = builder.profile == null ? CertificateProfile.DEFAULT : builder.profile;
         // null vs non-null distinguishes 'use the algorithm-aware default'
         // from 'use exactly these'. Defensive copy; immutable view returned
         // from the getter.
@@ -103,6 +107,14 @@ public final class CertInfo {
         return extendedKeyUsages;
     }
 
+    // The selected certificate profile; never null (defaults to
+    // CertificateProfile.DEFAULT). The profile supplies KeyUsage /
+    // ExtendedKeyUsage defaults that explicit Builder.keyUsage(...) /
+    // Builder.extendedKeyUsage(...) calls still override.
+    public CertificateProfile getProfile() {
+        return profile;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -113,13 +125,14 @@ public final class CertInfo {
                 && Objects.equals(dnsNames, that.dnsNames)
                 && Objects.equals(ipAddresses, that.ipAddresses)
                 && Objects.equals(keyUsages, that.keyUsages)
-                && Objects.equals(extendedKeyUsages, that.extendedKeyUsages);
+                && Objects.equals(extendedKeyUsages, that.extendedKeyUsages)
+                && profile == that.profile;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(subjectName, validFrom, validUntil, dnsNames,
-                ipAddresses, keyUsages, extendedKeyUsages);
+                ipAddresses, keyUsages, extendedKeyUsages, profile);
     }
 
     @Override
@@ -132,6 +145,7 @@ public final class CertInfo {
                 + ", ipAddresses=" + ipAddresses
                 + ", keyUsages=" + keyUsages
                 + ", extendedKeyUsages=" + extendedKeyUsages
+                + ", profile=" + profile
                 + '}';
     }
 
@@ -143,6 +157,7 @@ public final class CertInfo {
         private final List<String> ipAddresses = new ArrayList<>();
         private EnumSet<KeyUsageBit> keyUsages;
         private EnumSet<ExtendedKeyUsageId> extendedKeyUsages;
+        private CertificateProfile profile;
 
         private Builder() {
         }
@@ -202,6 +217,15 @@ public final class CertInfo {
                 this.extendedKeyUsages = EnumSet.noneOf(ExtendedKeyUsageId.class);
             }
             this.extendedKeyUsages.add(id);
+            return this;
+        }
+
+        // Select a certificate profile (eg. CertificateProfile.BRCAC). The
+        // profile supplies KeyUsage / ExtendedKeyUsage defaults for the leaf;
+        // explicit keyUsage(...) / extendedKeyUsage(...) calls on this builder
+        // still take precedence. Unset means CertificateProfile.DEFAULT.
+        public Builder profile(CertificateProfile profile) {
+            this.profile = Objects.requireNonNull(profile, "profile must not be null");
             return this;
         }
 

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertificateProfile.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertificateProfile.java
@@ -1,8 +1,10 @@
 package com.elevenware.quickpki;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A named bundle of leaf-certificate policy - the KeyUsage and ExtendedKeyUsage
@@ -60,6 +62,29 @@ public enum CertificateProfile {
                 : Collections.unmodifiableSet(EnumSet.copyOf(keyUsages));
         this.extendedKeyUsages = extendedKeyUsages == null ? null
                 : Collections.unmodifiableSet(EnumSet.copyOf(extendedKeyUsages));
+    }
+
+    /**
+     * Resolves a profile from its name, case-insensitively. A {@code null} or
+     * blank name resolves to {@link #DEFAULT} so callers can treat "no profile
+     * supplied" and "DEFAULT profile" identically.
+     *
+     * @throws IllegalArgumentException if {@code name} matches no profile
+     */
+    public static CertificateProfile fromName(String name) {
+        if (name == null || name.isBlank()) {
+            return DEFAULT;
+        }
+        String trimmed = name.trim();
+        for (CertificateProfile profile : values()) {
+            if (profile.name().equalsIgnoreCase(trimmed)) {
+                return profile;
+            }
+        }
+        throw new IllegalArgumentException("Unknown certificate profile '" + name
+                + "'; valid profiles are " + Arrays.stream(values())
+                        .map(Enum::name)
+                        .collect(Collectors.joining(", ")));
     }
 
     /**

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertificateProfile.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertificateProfile.java
@@ -1,0 +1,82 @@
+package com.elevenware.quickpki;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * A named bundle of leaf-certificate policy - the KeyUsage and ExtendedKeyUsage
+ * a certificate should carry. Selecting a profile on a {@link CertInfo} lets a
+ * caller issue a certificate shaped for a particular use case without spelling
+ * out every usage bit by hand.
+ *
+ * <p>A profile only supplies <em>defaults</em>. Explicit
+ * {@link CertInfo.Builder#keyUsage(KeyUsageBit)} /
+ * {@link CertInfo.Builder#extendedKeyUsage(ExtendedKeyUsageId)} calls still
+ * win, so a profile can be picked as a baseline and then tweaked.
+ *
+ * <p>{@link #BRCAC} and {@link #BRSEAL} model the transport and signing
+ * certificate profiles from the Open Finance Brasil certificate standards.
+ */
+public enum CertificateProfile {
+
+    /**
+     * No opinion: KeyUsage is chosen from the leaf's key algorithm and
+     * ExtendedKeyUsage defaults to serverAuth + clientAuth. This is the
+     * behaviour QuickPki had before profiles existed.
+     */
+    DEFAULT(null, null),
+
+    /** TLS server: algorithm-default KeyUsage, ExtendedKeyUsage = serverAuth. */
+    TLS_SERVER(null, EnumSet.of(ExtendedKeyUsageId.SERVER_AUTH)),
+
+    /** TLS client: algorithm-default KeyUsage, ExtendedKeyUsage = clientAuth. */
+    TLS_CLIENT(null, EnumSet.of(ExtendedKeyUsageId.CLIENT_AUTH)),
+
+    /**
+     * Open Finance Brasil transport certificate (BRCAC): KeyUsage
+     * digitalSignature + keyEncipherment, ExtendedKeyUsage clientAuth. Used for
+     * mutual-TLS client authentication between Open Finance participants.
+     */
+    BRCAC(
+            EnumSet.of(KeyUsageBit.DIGITAL_SIGNATURE, KeyUsageBit.KEY_ENCIPHERMENT),
+            EnumSet.of(ExtendedKeyUsageId.CLIENT_AUTH)),
+
+    /**
+     * Open Finance Brasil signing certificate (BRSEAL): KeyUsage
+     * digitalSignature + nonRepudiation, and no ExtendedKeyUsage extension at
+     * all. Used to sign message payloads (JWS) between participants.
+     */
+    BRSEAL(
+            EnumSet.of(KeyUsageBit.DIGITAL_SIGNATURE, KeyUsageBit.NON_REPUDIATION),
+            EnumSet.noneOf(ExtendedKeyUsageId.class));
+
+    private final Set<KeyUsageBit> keyUsages;
+    private final Set<ExtendedKeyUsageId> extendedKeyUsages;
+
+    CertificateProfile(EnumSet<KeyUsageBit> keyUsages,
+                       EnumSet<ExtendedKeyUsageId> extendedKeyUsages) {
+        this.keyUsages = keyUsages == null ? null
+                : Collections.unmodifiableSet(EnumSet.copyOf(keyUsages));
+        this.extendedKeyUsages = extendedKeyUsages == null ? null
+                : Collections.unmodifiableSet(EnumSet.copyOf(extendedKeyUsages));
+    }
+
+    /**
+     * The KeyUsage bits this profile mandates, or {@code null} when the profile
+     * leaves KeyUsage to QuickPki's algorithm-aware default.
+     */
+    public Set<KeyUsageBit> keyUsages() {
+        return keyUsages;
+    }
+
+    /**
+     * The ExtendedKeyUsage purposes this profile mandates. {@code null} means
+     * the profile has no opinion (the serverAuth + clientAuth default applies);
+     * an empty set means the certificate carries no ExtendedKeyUsage extension
+     * at all (eg. {@link #BRSEAL}).
+     */
+    public Set<ExtendedKeyUsageId> extendedKeyUsages() {
+        return extendedKeyUsages;
+    }
+}

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/Csr.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/Csr.java
@@ -32,6 +32,10 @@ import java.util.Objects;
  */
 public final class Csr {
 
+    // jurisdictionCountryName; BCStyle has no constant for this OID.
+    private static final org.bouncycastle.asn1.ASN1ObjectIdentifier JURISDICTION_COUNTRY_NAME =
+            new org.bouncycastle.asn1.ASN1ObjectIdentifier("1.3.6.1.4.1.311.60.2.1.3");
+
     private Csr() {}
 
     /**
@@ -87,6 +91,11 @@ public final class Csr {
         applyRdn(subject, BCStyle.DN_QUALIFIER, builder::dnQualifier);
         applyRdn(subject, BCStyle.L, builder::locality);
         applyRdn(subject, BCStyle.ST, builder::stateOrProvince);
+        applyRdn(subject, BCStyle.ORGANIZATION_IDENTIFIER, builder::organizationIdentifier);
+        applyRdn(subject, BCStyle.BUSINESS_CATEGORY, builder::businessCategory);
+        applyRdn(subject, JURISDICTION_COUNTRY_NAME, builder::jurisdictionCountry);
+        applyRdn(subject, BCStyle.SERIALNUMBER, builder::serialNumber);
+        applyRdn(subject, BCStyle.UID, builder::userId);
         return builder.build();
     }
 

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
@@ -1,5 +1,6 @@
 package com.elevenware.quickpki;
 
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
@@ -45,6 +46,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A very small library for generating certs for tests. It isn't in any way a viable PKI
@@ -132,15 +134,19 @@ public class QuickPki {
         return serial;
     }
 
-    // If the caller specified explicit KeyUsage bits on the CertInfo, OR them
-    // together. Otherwise default by key algorithm: RSA gets
-    // digitalSignature|keyEncipherment; EC gets digitalSignature|keyAgreement
-    // because keyEncipherment is RSA key-transport semantics and some strict
-    // validators reject it on EC certs.
+    // Resolves the leaf KeyUsage. Precedence: explicit CertInfo bits win;
+    // otherwise the selected profile's bits; otherwise default by key
+    // algorithm - RSA gets digitalSignature|keyEncipherment, EC gets
+    // digitalSignature|keyAgreement because keyEncipherment is RSA
+    // key-transport semantics and some strict validators reject it on EC.
     private KeyUsage leafKeyUsageFor(PublicKey publicKey, CertInfo info) {
-        if (info.getKeyUsages() != null) {
+        Set<KeyUsageBit> usages = info.getKeyUsages();
+        if (usages == null) {
+            usages = info.getProfile().keyUsages();
+        }
+        if (usages != null) {
             int bits = 0;
-            for (KeyUsageBit b : info.getKeyUsages()) {
+            for (KeyUsageBit b : usages) {
                 bits |= b.bit();
             }
             return new KeyUsage(bits);
@@ -152,12 +158,21 @@ public class QuickPki {
         return new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment);
     }
 
-    // If the caller specified explicit ExtendedKeyUsage purposes, use those
-    // verbatim. Otherwise default to serverAuth + clientAuth, the right shape
-    // for both server and client TLS scenarios.
+    // Resolves the leaf ExtendedKeyUsage. Precedence: explicit CertInfo
+    // purposes win; otherwise the selected profile's purposes; otherwise
+    // default to serverAuth + clientAuth. Returns null when no EKU extension
+    // should be emitted at all - the profile can request this with an empty
+    // purpose set (eg. CertificateProfile.BRSEAL).
     private ExtendedKeyUsage leafEkuFor(CertInfo info) {
-        if (info.getExtendedKeyUsages() != null) {
-            KeyPurposeId[] purposes = info.getExtendedKeyUsages().stream()
+        Set<ExtendedKeyUsageId> eku = info.getExtendedKeyUsages();
+        if (eku == null) {
+            eku = info.getProfile().extendedKeyUsages();
+        }
+        if (eku != null) {
+            if (eku.isEmpty()) {
+                return null;
+            }
+            KeyPurposeId[] purposes = eku.stream()
                     .map(ExtendedKeyUsageId::keyPurposeId)
                     .toArray(KeyPurposeId[]::new);
             return new ExtendedKeyUsage(purposes);
@@ -449,7 +464,10 @@ public class QuickPki {
         JcaX509ExtensionUtils extUtils = new JcaX509ExtensionUtils();
         certificateBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
         certificateBuilder.addExtension(Extension.keyUsage, true, leafKeyUsageFor(publicKey, info));
-        certificateBuilder.addExtension(Extension.extendedKeyUsage, false, leafEkuFor(info));
+        ExtendedKeyUsage eku = leafEkuFor(info);
+        if (eku != null) {
+            certificateBuilder.addExtension(Extension.extendedKeyUsage, false, eku);
+        }
         certificateBuilder.addExtension(Extension.subjectKeyIdentifier, false,
                 extUtils.createSubjectKeyIdentifier(publicKey));
         certificateBuilder.addExtension(Extension.authorityKeyIdentifier, false,
@@ -500,6 +518,26 @@ public class QuickPki {
         if(info.getStateOrProvince() != null) {
             builder.addRDN(BCStyle.ST, info.getStateOrProvince());
         }
+        if(info.getOrganizationIdentifier() != null) {
+            builder.addRDN(BCStyle.ORGANIZATION_IDENTIFIER, info.getOrganizationIdentifier());
+        }
+        if(info.getBusinessCategory() != null) {
+            builder.addRDN(BCStyle.BUSINESS_CATEGORY, info.getBusinessCategory());
+        }
+        if(info.getJurisdictionCountry() != null) {
+            builder.addRDN(JURISDICTION_COUNTRY_NAME, info.getJurisdictionCountry());
+        }
+        if(info.getSerialNumber() != null) {
+            builder.addRDN(BCStyle.SERIALNUMBER, info.getSerialNumber());
+        }
+        if(info.getUserId() != null) {
+            builder.addRDN(BCStyle.UID, info.getUserId());
+        }
         return builder.build();
     }
+
+    // jurisdictionCountryName, the EV-style jurisdiction-of-incorporation
+    // country. BCStyle has no constant for it, so we name the OID directly.
+    private static final ASN1ObjectIdentifier JURISDICTION_COUNTRY_NAME =
+            new ASN1ObjectIdentifier("1.3.6.1.4.1.311.60.2.1.3");
 }

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/SubjectName.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/SubjectName.java
@@ -11,6 +11,11 @@ public final class SubjectName {
     private final String dnQualifier;
     private final String locality;
     private final String stateOrProvince;
+    private final String organizationIdentifier;
+    private final String businessCategory;
+    private final String jurisdictionCountry;
+    private final String serialNumber;
+    private final String userId;
 
     private SubjectName(Builder builder) {
         this.commonName = builder.commonName;
@@ -20,6 +25,11 @@ public final class SubjectName {
         this.dnQualifier = builder.dnQualifier;
         this.locality = builder.locality;
         this.stateOrProvince = builder.stateOrProvince;
+        this.organizationIdentifier = builder.organizationIdentifier;
+        this.businessCategory = builder.businessCategory;
+        this.jurisdictionCountry = builder.jurisdictionCountry;
+        this.serialNumber = builder.serialNumber;
+        this.userId = builder.userId;
     }
 
     public static Builder builder() {
@@ -54,6 +64,36 @@ public final class SubjectName {
         return stateOrProvince;
     }
 
+    // organizationIdentifier (OID 2.5.4.97). Open Finance Brasil carries the
+    // participant code here, formatted as "OFBBR-<code>".
+    public String getOrganizationIdentifier() {
+        return organizationIdentifier;
+    }
+
+    // businessCategory (OID 2.5.4.15). Open Finance Brasil expects one of
+    // "Private Organization", "Government Entity", "Business Entity" or
+    // "Non-Commercial Entity".
+    public String getBusinessCategory() {
+        return businessCategory;
+    }
+
+    // jurisdictionCountryName (OID 1.3.6.1.4.1.311.60.2.1.3), the EV-style
+    // jurisdiction-of-incorporation country. Open Finance Brasil uses "BR".
+    public String getJurisdictionCountry() {
+        return jurisdictionCountry;
+    }
+
+    // serialNumber (OID 2.5.4.5) RDN - not the certificate serial number.
+    // Open Finance Brasil carries the organisation CNPJ here.
+    public String getSerialNumber() {
+        return serialNumber;
+    }
+
+    // userId / UID (OID 0.9.2342.19200300.100.1.1).
+    public String getUserId() {
+        return userId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -64,13 +104,19 @@ public final class SubjectName {
                 && Objects.equals(organizationUnit, that.organizationUnit)
                 && Objects.equals(dnQualifier, that.dnQualifier)
                 && Objects.equals(locality, that.locality)
-                && Objects.equals(stateOrProvince, that.stateOrProvince);
+                && Objects.equals(stateOrProvince, that.stateOrProvince)
+                && Objects.equals(organizationIdentifier, that.organizationIdentifier)
+                && Objects.equals(businessCategory, that.businessCategory)
+                && Objects.equals(jurisdictionCountry, that.jurisdictionCountry)
+                && Objects.equals(serialNumber, that.serialNumber)
+                && Objects.equals(userId, that.userId);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(commonName, country, organization, organizationUnit,
-                dnQualifier, locality, stateOrProvince);
+                dnQualifier, locality, stateOrProvince, organizationIdentifier,
+                businessCategory, jurisdictionCountry, serialNumber, userId);
     }
 
     @Override
@@ -83,6 +129,11 @@ public final class SubjectName {
                 + ", dnQualifier=" + dnQualifier
                 + ", locality=" + locality
                 + ", stateOrProvince=" + stateOrProvince
+                + ", organizationIdentifier=" + organizationIdentifier
+                + ", businessCategory=" + businessCategory
+                + ", jurisdictionCountry=" + jurisdictionCountry
+                + ", serialNumber=" + serialNumber
+                + ", userId=" + userId
                 + '}';
     }
 
@@ -94,6 +145,11 @@ public final class SubjectName {
         private String dnQualifier;
         private String locality;
         private String stateOrProvince;
+        private String organizationIdentifier;
+        private String businessCategory;
+        private String jurisdictionCountry;
+        private String serialNumber;
+        private String userId;
 
         private Builder() {
         }
@@ -130,6 +186,31 @@ public final class SubjectName {
 
         public Builder stateOrProvince(String stateOrProvince) {
             this.stateOrProvince = stateOrProvince;
+            return this;
+        }
+
+        public Builder organizationIdentifier(String organizationIdentifier) {
+            this.organizationIdentifier = organizationIdentifier;
+            return this;
+        }
+
+        public Builder businessCategory(String businessCategory) {
+            this.businessCategory = businessCategory;
+            return this;
+        }
+
+        public Builder jurisdictionCountry(String jurisdictionCountry) {
+            this.jurisdictionCountry = jurisdictionCountry;
+            return this;
+        }
+
+        public Builder serialNumber(String serialNumber) {
+            this.serialNumber = serialNumber;
+            return this;
+        }
+
+        public Builder userId(String userId) {
+            this.userId = userId;
             return this;
         }
 

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
@@ -1303,6 +1303,169 @@ public class PkiTests {
         return builder.build(signer);
     }
 
+    // KeyUsage bit positions: digitalSignature=0, nonRepudiation=1,
+    // keyEncipherment=2, keyAgreement=4.
+    @Test
+    void brcacProfileSetsTransportKeyUsageAndClientAuth() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+
+        CertificateBundle bundle = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("transport.example.com").build())
+                .profile(CertificateProfile.BRCAC)
+                .build());
+
+        boolean[] keyUsage = bundle.getCertificate().getKeyUsage();
+        assertNotNull(keyUsage, "BRCAC leaf must have a KeyUsage extension");
+        assertTrue(keyUsage[0], "BRCAC must assert digitalSignature");
+        assertTrue(keyUsage[2], "BRCAC must assert keyEncipherment");
+        assertFalse(keyUsage[1], "BRCAC must NOT assert nonRepudiation");
+
+        List<String> eku = bundle.getCertificate().getExtendedKeyUsage();
+        assertNotNull(eku, "BRCAC must have an ExtendedKeyUsage extension");
+        assertEquals(List.of(KeyPurposeId.id_kp_clientAuth.getId()), eku,
+                "BRCAC ExtendedKeyUsage must be clientAuth only");
+    }
+
+    @Test
+    void brsealProfileSetsSigningKeyUsageAndOmitsExtendedKeyUsage() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+
+        CertificateBundle bundle = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Seal Co").build())
+                .profile(CertificateProfile.BRSEAL)
+                .build());
+
+        boolean[] keyUsage = bundle.getCertificate().getKeyUsage();
+        assertNotNull(keyUsage, "BRSEAL leaf must have a KeyUsage extension");
+        assertTrue(keyUsage[0], "BRSEAL must assert digitalSignature");
+        assertTrue(keyUsage[1], "BRSEAL must assert nonRepudiation");
+        assertFalse(keyUsage[2], "BRSEAL must NOT assert keyEncipherment");
+
+        assertNull(bundle.getCertificate().getExtendedKeyUsage(),
+                "BRSEAL must carry no ExtendedKeyUsage extension");
+    }
+
+    @Test
+    void tlsServerAndClientProfilesPinExtendedKeyUsage() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+
+        List<String> serverEku = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("server").build())
+                .profile(CertificateProfile.TLS_SERVER)
+                .build())
+                .getCertificate().getExtendedKeyUsage();
+        assertEquals(List.of(KeyPurposeId.id_kp_serverAuth.getId()), serverEku);
+
+        List<String> clientEku = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("client").build())
+                .profile(CertificateProfile.TLS_CLIENT)
+                .build())
+                .getCertificate().getExtendedKeyUsage();
+        assertEquals(List.of(KeyPurposeId.id_kp_clientAuth.getId()), clientEku);
+    }
+
+    @Test
+    void explicitUsagesOverrideProfileDefaults() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+
+        // BRSEAL would default to no EKU and digitalSignature+nonRepudiation;
+        // explicit builder calls must win over the profile.
+        CertificateBundle bundle = pki.issueCertificate(CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Override").build())
+                .profile(CertificateProfile.BRSEAL)
+                .keyUsage(KeyUsageBit.DIGITAL_SIGNATURE)
+                .extendedKeyUsage(ExtendedKeyUsageId.CODE_SIGNING)
+                .build());
+
+        boolean[] keyUsage = bundle.getCertificate().getKeyUsage();
+        assertTrue(keyUsage[0], "explicit digitalSignature must be present");
+        assertFalse(keyUsage[1], "profile's nonRepudiation must NOT survive the override");
+
+        List<String> eku = bundle.getCertificate().getExtendedKeyUsage();
+        assertEquals(List.of(KeyPurposeId.id_kp_codeSigning.getId()), eku,
+                "explicit ExtendedKeyUsage must override the profile");
+    }
+
+    @Test
+    void defaultProfileKeepsAlgorithmAwareDefaults() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+
+        CertInfo info = CertInfo.builder()
+                .subjectName(SubjectName.builder().commonName("Default").build())
+                .build();
+        assertEquals(CertificateProfile.DEFAULT, info.getProfile(),
+                "an unset profile must resolve to DEFAULT");
+
+        CertificateBundle bundle = pki.issueCertificate(info);
+        boolean[] keyUsage = bundle.getCertificate().getKeyUsage();
+        assertTrue(keyUsage[0], "DEFAULT RSA leaf must have digitalSignature");
+        assertTrue(keyUsage[2], "DEFAULT RSA leaf must have keyEncipherment");
+
+        List<String> eku = bundle.getCertificate().getExtendedKeyUsage();
+        assertTrue(eku.contains(KeyPurposeId.id_kp_serverAuth.getId()));
+        assertTrue(eku.contains(KeyPurposeId.id_kp_clientAuth.getId()));
+    }
+
+    @Test
+    void profileBuilderRejectsNull() {
+        assertThrows(NullPointerException.class,
+                () -> CertInfo.builder().profile(null));
+    }
+
+    @Test
+    void openFinanceSubjectAttributesAppearInIssuedCertificate() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+
+        CertificateBundle bundle = pki.issueCertificate(CertInfo.builder()
+                .profile(CertificateProfile.BRCAC)
+                .subjectName(SubjectName.builder()
+                        .commonName("transport.example.com")
+                        .country("BR")
+                        .organization("Example Participant Ltda")
+                        .organizationIdentifier("OFBBR-12345678")
+                        .businessCategory("Private Organization")
+                        .jurisdictionCountry("BR")
+                        .serialNumber("12345678000199")
+                        .userId("software-statement-uuid")
+                        .build())
+                .dnsName("transport.example.com")
+                .build());
+
+        X500Name subject = new JcaX509CertificateHolder(bundle.getCertificate()).getSubject();
+        assertEquals("OFBBR-12345678",
+                subject.getRDNs(BCStyle.ORGANIZATION_IDENTIFIER)[0].getFirst().getValue().toString());
+        assertEquals("Private Organization",
+                subject.getRDNs(BCStyle.BUSINESS_CATEGORY)[0].getFirst().getValue().toString());
+        assertEquals("12345678000199",
+                subject.getRDNs(BCStyle.SERIALNUMBER)[0].getFirst().getValue().toString());
+        assertEquals("software-statement-uuid",
+                subject.getRDNs(BCStyle.UID)[0].getFirst().getValue().toString());
+        assertEquals("BR", subject.getRDNs(
+                new org.bouncycastle.asn1.ASN1ObjectIdentifier("1.3.6.1.4.1.311.60.2.1.3"))[0]
+                .getFirst().getValue().toString());
+    }
+
+    @Test
+    void csrRoundTripsOpenFinanceSubjectAttributes() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+        KeyPair subscriberKeys = generateRsaKeyPair();
+
+        PKCS10CertificationRequest csr = buildCsr(subscriberKeys,
+                "CN=transport.example.com,O=Example,2.5.4.97=#0c0e4f464242522d3132333435363738",
+                List.of("transport.example.com"),
+                List.of());
+
+        SubjectName fromCsr = Csr.subjectName(csr);
+        assertEquals("OFBBR-12345678", fromCsr.getOrganizationIdentifier(),
+                "organizationIdentifier must survive the CSR round-trip");
+
+        CertificateBundle bundle = pki.issueCertificate(csr,
+                CertInfo.fromCsr(csr).profile(CertificateProfile.BRCAC).build());
+        X500Name subject = new JcaX509CertificateHolder(bundle.getCertificate()).getSubject();
+        assertEquals("OFBBR-12345678",
+                subject.getRDNs(BCStyle.ORGANIZATION_IDENTIFIER)[0].getFirst().getValue().toString());
+    }
+
     @BeforeAll
     static void setup() {
         Security.addProvider(new BouncyCastleProvider());


### PR DESCRIPTION
## Summary

Adds a notion of named **certificate profiles** so callers can issue leaf certificates shaped for a specific use case without spelling out every usage bit. Includes the two Open Finance Brasil profiles requested — **BRCAC** (transport / mTLS client) and **BRSEAL** (message signing / seal) — and wires profile selection through both server components.

### Library (`quick-pki-lib`)

A new `CertificateProfile` enum is selected on `CertInfo` via `CertInfo.builder().profile(...)`. A profile only supplies *defaults*: explicit `keyUsage(...)` / `extendedKeyUsage(...)` builder calls still win.

| Profile | KeyUsage | ExtendedKeyUsage |
|---|---|---|
| `DEFAULT` | algorithm-aware (prior behaviour) | serverAuth + clientAuth |
| `TLS_SERVER` | algorithm-aware | serverAuth |
| `TLS_CLIENT` | algorithm-aware | clientAuth |
| `BRCAC` | digitalSignature + keyEncipherment | clientAuth |
| `BRSEAL` | digitalSignature + nonRepudiation | *(no EKU extension)* |

`SubjectName` gained the X.500 attributes Open Finance Brasil certificates require (`organizationIdentifier`, `businessCategory`, `jurisdictionCountryName`, `serialNumber`, `userId`); `Csr.subjectName(...)` round-trips them. `CertificateProfile.fromName(...)` resolves a profile name case-insensitively.

### cert-api server (`quick-pki-cert-api`)

`POST /v1/certificates` accepts an optional `profile` field in the JSON body (`DEFAULT`, `TLS_SERVER`, `TLS_CLIENT`, `BRCAC`, `BRSEAL`). An unknown name returns `400 invalid_request`. The OpenAPI document advertises the new field. Omitting it preserves prior behaviour (`DEFAULT`).

### ACME server (`quick-pki-acme-server`)

RFC 8555's finalize request carries only a CSR — there's no per-order profile field — so profile selection is a **server-level** setting via the `ACME_CERTIFICATE_PROFILE` env var. It defaults to `TLS_SERVER` (the ACME server mints domain-validated TLS server certs), which exactly preserves the local CA's prior serverAuth-only behaviour. The remote-issuer path now forwards the configured profile to the cert-api, making delegated issuance consistent with the local CA (previously the remote path silently got `DEFAULT` = serverAuth+clientAuth).

## Test plan

- [x] `mvn test` — all modules green
- [x] `quick-pki-lib` PkiTests: 72 (8 new) — BRCAC/BRSEAL/TLS profiles, override precedence, OFB DN attributes, CSR round-trip
- [x] `quick-pki-cert-api` CertApiServerTest: 13 (2 new) — issuing under a requested profile, rejecting an unknown profile
- [x] `quick-pki-acme-server` RemoteCertificateIssuerTest: 5 (1 new) — the configured profile is forwarded in the remote request body
- [x] Default/omitted profile reproduces pre-existing behaviour in all three modules

https://claude.ai/code/session_01KDr9qts8njg37yVMic3WCX