### PR TITLE
Add EU QWAC/QSEAL certificate profiles and cert-api helpers

### DIFF
--- a/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertApiModels.java
+++ b/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertApiModels.java
@@ -98,6 +98,62 @@ record BrsealOpensslConfigRequest(
 }
 
 /**
+ * Inbound JSON request body for {@code POST /v1/openssl-configs/qwac}.
+ * Collects the QWAC subject attributes and PSD2 metadata the server bakes
+ * into the openssl {@code req} config. The config emits the standard ETSI
+ * QC statements (QcCompliance + QcType=web) and, when {@code psd2Roles} is
+ * populated, the PSD2 qcStatement listing the PSP's roles and NCA.
+ *
+ * <p>Field reference: ETSI EN 319 412-1 §5.1 for the subject DN attributes,
+ * ETSI TS 119 495 §5 for the PSD2 organizationIdentifier and qcStatement
+ * payload.
+ */
+record QwacOpensslConfigRequest(
+        String commonName,
+        String country,
+        String stateOrProvince,
+        String locality,
+        String organization,
+        String organizationIdentifier,
+        String serialNumber,
+        List<String> dnsNames,
+        List<String> psd2Roles,
+        String ncaName,
+        String ncaId,
+        List<PdsLocationRequest> pdsLocations
+) {
+}
+
+/**
+ * Inbound JSON request body for {@code POST /v1/openssl-configs/qseal}.
+ * Same shape as {@link QwacOpensslConfigRequest} but produces a config for
+ * the QSEAL profile - no DNS SANs, QcType set to {@code id-etsi-qct-eseal},
+ * optional {@code QcSSCD} qcStatement when {@code onQscd} is {@code true}.
+ */
+record QsealOpensslConfigRequest(
+        String commonName,
+        String country,
+        String stateOrProvince,
+        String locality,
+        String organization,
+        String organizationIdentifier,
+        String serialNumber,
+        List<String> psd2Roles,
+        String ncaName,
+        String ncaId,
+        List<PdsLocationRequest> pdsLocations,
+        boolean onQscd
+) {
+}
+
+/**
+ * A single PDS URL / language pair carried in the {@code QcPDS} qcStatement
+ * payload. Language must be an ISO 639-1 two-letter code (eg. {@code "en"}).
+ */
+record PdsLocationRequest(String url, String language) {
+}
+
+/**
  * Response body for {@code POST /v1/openssl-configs/{brcac,brseal}}: the
  * generated openssl {@code req} config, base64-encoded (consistent with how
  * CSRs and certs travel on this API), plus a suggested filename for callers

--- a/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertApiServer.java
+++ b/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/CertApiServer.java
@@ -89,6 +89,8 @@ final class CertApiServer {
         routes.get("/v1/certificates/{id}", this::getCertificate);
         routes.post("/v1/openssl-configs/brcac", this::brcacOpensslConfig);
         routes.post("/v1/openssl-configs/brseal", this::brsealOpensslConfig);
+        routes.post("/v1/openssl-configs/qwac", this::qwacOpensslConfig);
+        routes.post("/v1/openssl-configs/qseal", this::qsealOpensslConfig);
         routes.get("/issuer/root.pem", ctx -> ctx.contentType("application/pem-certificate-chain")
                 .result(caService.issuerPem()));
         routes.get("/healthz", this::liveness);
@@ -196,6 +198,20 @@ final class CertApiServer {
                 "a JSON body with the BRSEAL subject attributes");
         String config = OpensslConfigs.forBrseal(request);
         ctx.json(new OpensslConfigResponse("brseal.cnf", base64(config)));
+    }
+
+    private void qwacOpensslConfig(Context ctx) {
+        QwacOpensslConfigRequest request = parseBody(ctx, QwacOpensslConfigRequest.class,
+                "a JSON body with the QWAC subject attributes");
+        String config = OpensslConfigs.forQwac(request);
+        ctx.json(new OpensslConfigResponse("qwac.cnf", base64(config)));
+    }
+
+    private void qsealOpensslConfig(Context ctx) {
+        QsealOpensslConfigRequest request = parseBody(ctx, QsealOpensslConfigRequest.class,
+                "a JSON body with the QSEAL subject attributes");
+        String config = OpensslConfigs.forQseal(request);
+        ctx.json(new OpensslConfigResponse("qseal.cnf", base64(config)));
     }
 
     private void persistAndRespond(Context ctx, CertificateAuthorityService.Issued issued) {

--- a/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/OpensslConfigs.java
+++ b/quick-pki-cert-api/src/main/java/com/elevenware/quickpki/certapi/OpensslConfigs.java
@@ -1,9 +1,16 @@
 package com.elevenware.quickpki.certapi;
 
+import com.elevenware.quickpki.EuQualified;
+import com.elevenware.quickpki.QcStatement;
+
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Generates openssl {@code req} config files from a caller's structured
@@ -156,6 +163,181 @@ final class OpensslConfigs {
             sb.append(line).append('\n');
         }
         return sb.toString();
+    }
+
+    static String forQwac(QwacOpensslConfigRequest request) {
+        requireNonBlank(request.commonName(), "commonName");
+        requireNonBlank(request.country(), "country");
+        if (request.country().length() != 2) {
+            throw new CertApiException(400, "invalid_request",
+                    "'country' must be a two-letter ISO 3166-1 code");
+        }
+        requireNonBlank(request.organization(), "organization");
+        requireNonBlank(request.organizationIdentifier(), "organizationIdentifier");
+        List<String> dnsNames = request.dnsNames() == null ? List.of() : request.dnsNames();
+        if (dnsNames.isEmpty()) {
+            throw new CertApiException(400, "invalid_request",
+                    "QWAC requires at least one entry in 'dnsNames'");
+        }
+
+        Map<String, String> dn = euQualifiedDn(request.country(), request.stateOrProvince(),
+                request.locality(), request.organization(), request.serialNumber(),
+                request.organizationIdentifier(), request.commonName());
+
+        List<String> sanLines = new ArrayList<>();
+        int i = 1;
+        for (String dnsName : dnsNames) {
+            sanLines.add("DNS." + i++ + " = " + dnsName);
+        }
+
+        List<QcStatement> statements = new ArrayList<>();
+        statements.add(EuQualified.qcCompliance());
+        statements.add(EuQualified.qcType(EuQualified.OID_QC_TYPE_WEB));
+        appendPsd2(statements, request.psd2Roles(), request.ncaName(), request.ncaId());
+        appendQcPds(statements, request.pdsLocations());
+        String qcDer = encodeQcStatementsAsHex(statements);
+
+        return renderConfig(euQualifiedOids(), dn, "ext_qwac",
+                qwacExtensions(sanLines, qcDer));
+    }
+
+    static String forQseal(QsealOpensslConfigRequest request) {
+        requireNonBlank(request.commonName(), "commonName");
+        requireNonBlank(request.country(), "country");
+        if (request.country().length() != 2) {
+            throw new CertApiException(400, "invalid_request",
+                    "'country' must be a two-letter ISO 3166-1 code");
+        }
+        requireNonBlank(request.organization(), "organization");
+        requireNonBlank(request.organizationIdentifier(), "organizationIdentifier");
+
+        Map<String, String> dn = euQualifiedDn(request.country(), request.stateOrProvince(),
+                request.locality(), request.organization(), request.serialNumber(),
+                request.organizationIdentifier(), request.commonName());
+
+        List<QcStatement> statements = new ArrayList<>();
+        statements.add(EuQualified.qcCompliance());
+        statements.add(EuQualified.qcType(EuQualified.OID_QC_TYPE_ESEAL));
+        if (request.onQscd()) {
+            statements.add(EuQualified.qcSSCD());
+        }
+        appendPsd2(statements, request.psd2Roles(), request.ncaName(), request.ncaId());
+        appendQcPds(statements, request.pdsLocations());
+        String qcDer = encodeQcStatementsAsHex(statements);
+
+        return renderConfig(euQualifiedOids(), dn, "ext_qseal", qsealExtensions(qcDer));
+    }
+
+    private static Map<String, String> euQualifiedDn(
+            String country, String stateOrProvince, String locality,
+            String organization, String serialNumber, String organizationIdentifier,
+            String commonName) {
+        // ETSI EN 319 412-1 §5.1.2 / -3 §4.2 RDN order for the EU qualified
+        // legal-person subject; matches Csr.x500Name(... QWAC/QSEAL ...).
+        Map<String, String> dn = new LinkedHashMap<>();
+        dn.put("countryName", country);
+        if (stateOrProvince != null && !stateOrProvince.isBlank()) {
+            dn.put("stateOrProvinceName", stateOrProvince);
+        }
+        if (locality != null && !locality.isBlank()) {
+            dn.put("localityName", locality);
+        }
+        dn.put("organizationName", organization);
+        if (serialNumber != null && !serialNumber.isBlank()) {
+            dn.put("serialNumber", serialNumber);
+        }
+        dn.put("organizationIdentifier", organizationIdentifier);
+        dn.put("commonName", commonName);
+        return dn;
+    }
+
+    private static Map<String, String> euQualifiedOids() {
+        Map<String, String> oids = new LinkedHashMap<>();
+        // organizationIdentifier (2.5.4.97) has no built-in short name in
+        // openssl; declare it so the [dn] section can use it by name.
+        oids.put("organizationIdentifier", "2.5.4.97");
+        return oids;
+    }
+
+    private static String qwacExtensions(List<String> sanLines, String qcDerHex) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[ext_qwac]\n");
+        sb.append("keyUsage = critical, digitalSignature, keyEncipherment\n");
+        sb.append("extendedKeyUsage = serverAuth, clientAuth\n");
+        sb.append("subjectAltName = @san\n");
+        // qCStatements (1.3.6.1.5.5.7.1.3) emitted as a raw DER blob: the
+        // ETSI / PSD2 payload shapes are awkward to express in openssl's
+        // ASN1 macro language, and the binary stays stable as long as the
+        // caller's selections do.
+        sb.append("1.3.6.1.5.5.7.1.3 = DER:").append(qcDerHex).append('\n');
+        sb.append('\n');
+        sb.append("[san]\n");
+        for (String line : sanLines) {
+            sb.append(line).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static String qsealExtensions(String qcDerHex) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[ext_qseal]\n");
+        sb.append("keyUsage = critical, digitalSignature, nonRepudiation\n");
+        // QSEAL explicitly carries no ExtendedKeyUsage extension.
+        sb.append("1.3.6.1.5.5.7.1.3 = DER:").append(qcDerHex).append('\n');
+        return sb.toString();
+    }
+
+    private static void appendPsd2(List<QcStatement> statements, List<String> roleNames,
+                                   String ncaName, String ncaId) {
+        if (roleNames == null || roleNames.isEmpty()) {
+            return;
+        }
+        if (ncaName == null || ncaName.isBlank() || ncaId == null || ncaId.isBlank()) {
+            throw new CertApiException(400, "invalid_request",
+                    "'ncaName' and 'ncaId' are required when 'psd2Roles' is supplied");
+        }
+        Set<EuQualified.Psd2Role> roles = EnumSet.noneOf(EuQualified.Psd2Role.class);
+        for (String name : roleNames) {
+            try {
+                roles.add(EuQualified.Psd2Role.valueOf(name));
+            } catch (IllegalArgumentException e) {
+                throw new CertApiException(400, "invalid_request",
+                        "unknown PSD2 role '" + name + "'; valid roles are "
+                                + EuQualified.Psd2Role.PSP_AS + ", " + EuQualified.Psd2Role.PSP_PI
+                                + ", " + EuQualified.Psd2Role.PSP_AI + ", " + EuQualified.Psd2Role.PSP_IC);
+            }
+        }
+        statements.add(EuQualified.psd2QcStatement(roles, ncaName, ncaId));
+    }
+
+    private static void appendQcPds(List<QcStatement> statements, List<PdsLocationRequest> pdsLocations) {
+        if (pdsLocations == null || pdsLocations.isEmpty()) {
+            return;
+        }
+        List<EuQualified.PdsLocation> locations = new ArrayList<>(pdsLocations.size());
+        for (PdsLocationRequest loc : pdsLocations) {
+            if (loc.url() == null || loc.url().isBlank()
+                    || loc.language() == null || loc.language().isBlank()) {
+                throw new CertApiException(400, "invalid_request",
+                        "each pdsLocations entry must carry both 'url' and 'language'");
+            }
+            try {
+                locations.add(new EuQualified.PdsLocation(loc.url(), loc.language()));
+            } catch (IllegalArgumentException e) {
+                throw new CertApiException(400, "invalid_request", e.getMessage());
+            }
+        }
+        statements.add(EuQualified.qcPds(locations));
+    }
+
+    private static String encodeQcStatementsAsHex(List<QcStatement> statements) {
+        try {
+            byte[] der = com.elevenware.quickpki.Csr.encodeQcStatements(statements).getEncoded();
+            return HexFormat.of().withUpperCase().formatHex(der);
+        } catch (IOException e) {
+            throw new CertApiException(500, "server_error",
+                    "failed to encode qCStatements: " + e.getMessage());
+        }
     }
 
     private static String brsealExtensions(List<String> sanLines) {

--- a/quick-pki-cert-api/src/main/resources/openapi.yaml
+++ b/quick-pki-cert-api/src/main/resources/openapi.yaml
@@ -22,7 +22,9 @@ tags:
   - name: Certificates
     description: Issue and retrieve certificates
   - name: OpenSSL configs
-    description: Generate openssl req configs for the Open Finance Brasil certificate profiles
+    description: |
+      Generate openssl req configs for the Open Finance Brasil and EU eIDAS /
+      PSD2 qualified certificate profiles
   - name: Public
     description: Unauthenticated endpoints
 
@@ -126,6 +128,77 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/BrsealOpensslConfigRequest'
+      responses:
+        '200':
+          description: openssl config generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpensslConfigResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /v1/openssl-configs/qwac:
+    post:
+      tags: [OpenSSL configs]
+      summary: Generate an openssl req config for an EU PSD2 QWAC CSR
+      description: |
+        Returns an openssl `req` config that bakes in the QWAC subject DN
+        (in the ETSI EN 319 412-1 RDN order), the requested DNS SANs, the two
+        mandatory ETSI QC statements (QcCompliance + QcType=web), and -- when
+        `psd2Roles` is supplied -- the PSD2 qcStatement listing the PSP roles
+        and supervising NCA. The resulting CSR can be submitted to
+        `POST /v1/certificates` with `profile=QWAC` for issuance.
+      operationId: generateQwacOpensslConfig
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QwacOpensslConfigRequest'
+      responses:
+        '200':
+          description: openssl config generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpensslConfigResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /v1/openssl-configs/qseal:
+    post:
+      tags: [OpenSSL configs]
+      summary: Generate an openssl req config for an EU PSD2 QSEAL CSR
+      description: |
+        QSEAL counterpart to `/v1/openssl-configs/qwac`. Returns an openssl
+        `req` config with the QSEAL subject DN, no DNS SANs, no
+        ExtendedKeyUsage, and the mandatory ETSI QC statements
+        (QcCompliance + QcType=eseal). The resulting CSR can be submitted to
+        `POST /v1/certificates` with `profile=QSEAL` for issuance.
+      operationId: generateQsealOpensslConfig
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QsealOpensslConfigRequest'
       responses:
         '200':
           description: openssl config generated
@@ -279,16 +352,19 @@ components:
           example: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K
         profile:
           type: string
-          enum: [DEFAULT, TLS_SERVER, TLS_CLIENT, BRCAC, BRSEAL]
+          enum: [DEFAULT, TLS_SERVER, TLS_CLIENT, BRCAC, BRSEAL, QWAC, QSEAL]
           default: DEFAULT
           description: |
             The certificate profile to issue under. The profile fixes the
             leaf's KeyUsage and ExtendedKeyUsage. `BRCAC` and `BRSEAL` are the
-            Open Finance Brasil transport and signing certificate profiles.
-            For those profiles the CSR subject and subjectAltName extension
-            must carry the Open Finance Brasil attributes required by the
-            certificate standard; non-compliant CSRs are rejected with
-            `bad_csr`.
+            Open Finance Brasil transport and signing certificate profiles;
+            `QWAC` and `QSEAL` are the EU eIDAS / PSD2 Qualified Web
+            Authentication and Qualified Electronic Seal profiles
+            (ETSI EN 319 412-2/-3, ETSI TS 119 495 for the PSD2 attribute
+            set). For any non-DEFAULT profile the CSR subject, subjectAltName
+            extension, and -- for `QWAC` / `QSEAL` -- the requested
+            qCStatements extension must carry the attributes the profile
+            requires; non-compliant CSRs are rejected with `bad_csr`.
             Omitted or `DEFAULT` issues a general-purpose TLS leaf.
           example: BRCAC
 
@@ -401,6 +477,141 @@ components:
           type: string
           description: ICP-Brasil otherName `2.16.76.1.3.7`.
           example: "123456789012"
+
+    QwacOpensslConfigRequest:
+      type: object
+      required:
+        - commonName
+        - country
+        - organization
+        - organizationIdentifier
+        - dnsNames
+      properties:
+        commonName:
+          type: string
+          description: Subject commonName; typically the transport hostname.
+          example: psp.example.com
+        country:
+          type: string
+          minLength: 2
+          maxLength: 2
+          description: Two-letter ISO 3166-1 country code.
+          example: GB
+        stateOrProvince:
+          type: string
+        locality:
+          type: string
+        organization:
+          type: string
+          description: Legal-person registered name.
+          example: Example PSP plc
+        organizationIdentifier:
+          type: string
+          description: |
+            ETSI EN 319 412-1 §5.1.4 organizationIdentifier. For PSD2 use the
+            `PSD{country}-{NCA-Id}-{PSP-Id}` syntax from ETSI TS 119 495.
+          example: PSDGB-FCA-123456
+        serialNumber:
+          type: string
+          description: Optional subject serialNumber RDN.
+        dnsNames:
+          type: array
+          items:
+            type: string
+          description: DNS subjectAltName entries; at least one is required.
+          example:
+            - psp.example.com
+        psd2Roles:
+          type: array
+          items:
+            type: string
+            enum: [PSP_AS, PSP_PI, PSP_AI, PSP_IC]
+          description: |
+            Optional. When supplied the config emits the PSD2 qcStatement
+            (`0.4.0.19495.2`) listing these PSP roles and the supervising
+            NCA. Requires `ncaName` and `ncaId`.
+        ncaName:
+          type: string
+          description: Supervising National Competent Authority name (PSD2).
+          example: Financial Conduct Authority
+        ncaId:
+          type: string
+          description: Supervising NCA identifier (PSD2).
+          example: GB-FCA
+        pdsLocations:
+          type: array
+          description: |
+            Optional. PKI Disclosure Statement URLs, emitted as a `QcPDS`
+            qcStatement.
+          items:
+            $ref: '#/components/schemas/PdsLocation'
+
+    QsealOpensslConfigRequest:
+      type: object
+      required:
+        - commonName
+        - country
+        - organization
+        - organizationIdentifier
+      properties:
+        commonName:
+          type: string
+          example: PSP Seal
+        country:
+          type: string
+          minLength: 2
+          maxLength: 2
+          example: GB
+        stateOrProvince:
+          type: string
+        locality:
+          type: string
+        organization:
+          type: string
+          example: Example PSP plc
+        organizationIdentifier:
+          type: string
+          example: PSDGB-FCA-123456
+        serialNumber:
+          type: string
+        psd2Roles:
+          type: array
+          items:
+            type: string
+            enum: [PSP_AS, PSP_PI, PSP_AI, PSP_IC]
+          description: |
+            Optional. When supplied the config emits the PSD2 qcStatement.
+            Requires `ncaName` and `ncaId`.
+        ncaName:
+          type: string
+        ncaId:
+          type: string
+        pdsLocations:
+          type: array
+          items:
+            $ref: '#/components/schemas/PdsLocation'
+        onQscd:
+          type: boolean
+          default: false
+          description: |
+            When `true` the config emits the `QcSSCD` qcStatement, signalling
+            that the private key is held on a Qualified Signature/Seal
+            Creation Device.
+
+    PdsLocation:
+      type: object
+      required: [url, language]
+      properties:
+        url:
+          type: string
+          format: uri
+          example: https://example.com/pki/pds-en.pdf
+        language:
+          type: string
+          minLength: 2
+          maxLength: 2
+          description: ISO 639-1 two-letter language code.
+          example: en
 
     OpensslConfigResponse:
       type: object

--- a/quick-pki-cert-api/src/test/java/com/elevenware/quickpki/certapi/CertApiServerTest.java
+++ b/quick-pki-cert-api/src/test/java/com/elevenware/quickpki/certapi/CertApiServerTest.java
@@ -255,6 +255,153 @@ class CertApiServerTest {
     }
 
     @Test
+    void generatesAQwacOpensslConfig() throws Exception {
+        start("certificates:issue");
+        String body = """
+                {
+                  "commonName": "psp.example.com",
+                  "country": "GB",
+                  "organization": "Example PSP plc",
+                  "organizationIdentifier": "PSDGB-FCA-123456",
+                  "dnsNames": ["psp.example.com"],
+                  "psd2Roles": ["PSP_AS", "PSP_AI"],
+                  "ncaName": "Financial Conduct Authority",
+                  "ncaId": "GB-FCA",
+                  "pdsLocations": [
+                    { "url": "https://example.com/pki/pds-en.pdf", "language": "en" }
+                  ]
+                }
+                """;
+
+        HttpResponse<String> response = post("/v1/openssl-configs/qwac", "active-token", body);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        JsonNode jsonBody = Json.MAPPER.readTree(response.body());
+        assertThat(jsonBody.get("filename").asText()).isEqualTo("qwac.cnf");
+        String config = new String(Base64.getDecoder().decode(jsonBody.get("config").asText()),
+                StandardCharsets.UTF_8);
+        assertThat(config).contains("countryName = GB");
+        assertThat(config).contains("organizationName = Example PSP plc");
+        assertThat(config).contains("organizationIdentifier = PSDGB-FCA-123456");
+        assertThat(config).contains("commonName = psp.example.com");
+        assertThat(config).contains("DNS.1 = psp.example.com");
+        assertThat(config).contains("keyUsage = critical, digitalSignature, keyEncipherment");
+        assertThat(config).contains("extendedKeyUsage = serverAuth, clientAuth");
+        // The qCStatements extension is emitted as a raw DER blob.
+        assertThat(config).contains("1.3.6.1.5.5.7.1.3 = DER:");
+        // organizationIdentifier short-name is declared in the [oids] block.
+        assertThat(config).contains("organizationIdentifier = 2.5.4.97");
+    }
+
+    @Test
+    void generatesAQsealOpensslConfig() throws Exception {
+        start("certificates:issue");
+        String body = """
+                {
+                  "commonName": "PSP Seal",
+                  "country": "GB",
+                  "organization": "Example PSP plc",
+                  "organizationIdentifier": "PSDGB-FCA-123456",
+                  "onQscd": true
+                }
+                """;
+
+        HttpResponse<String> response = post("/v1/openssl-configs/qseal", "active-token", body);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        JsonNode jsonBody = Json.MAPPER.readTree(response.body());
+        assertThat(jsonBody.get("filename").asText()).isEqualTo("qseal.cnf");
+        String config = new String(Base64.getDecoder().decode(jsonBody.get("config").asText()),
+                StandardCharsets.UTF_8);
+        assertThat(config).contains("organizationIdentifier = PSDGB-FCA-123456");
+        assertThat(config).contains("keyUsage = critical, digitalSignature, nonRepudiation");
+        assertThat(config).contains("1.3.6.1.5.5.7.1.3 = DER:");
+        // QSEAL deliberately carries no EKU.
+        assertThat(config).doesNotContain("extendedKeyUsage");
+    }
+
+    @Test
+    void rejectsQwacOpensslConfigRequestMissingRequiredFields() throws Exception {
+        start("certificates:issue");
+
+        HttpResponse<String> response = post("/v1/openssl-configs/qwac", "active-token",
+                "{\"commonName\":\"psp.example.com\"}");
+
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(Json.MAPPER.readTree(response.body()).get("error").asText())
+                .isEqualTo("invalid_request");
+    }
+
+    @Test
+    void rejectsQwacOpensslConfigWithUnknownPsd2Role() throws Exception {
+        start("certificates:issue");
+        String body = """
+                {
+                  "commonName": "psp.example.com",
+                  "country": "GB",
+                  "organization": "Example PSP plc",
+                  "organizationIdentifier": "PSDGB-FCA-123456",
+                  "dnsNames": ["psp.example.com"],
+                  "psd2Roles": ["PSP_NONSENSE"],
+                  "ncaName": "Financial Conduct Authority",
+                  "ncaId": "GB-FCA"
+                }
+                """;
+
+        HttpResponse<String> response = post("/v1/openssl-configs/qwac", "active-token", body);
+
+        assertThat(response.statusCode()).isEqualTo(400);
+        assertThat(Json.MAPPER.readTree(response.body()).get("error_description").asText())
+                .contains("PSD2 role");
+    }
+
+    @Test
+    void qwacAndQsealOpensslConfigEndpointsAreAuthenticated() throws Exception {
+        start("certificates:issue");
+
+        HttpResponse<String> qwac = post("/v1/openssl-configs/qwac", "expired-token", "{}");
+        assertThat(qwac.statusCode()).isEqualTo(401);
+
+        HttpResponse<String> qseal = post("/v1/openssl-configs/qseal", "expired-token", "{}");
+        assertThat(qseal.statusCode()).isEqualTo(401);
+    }
+
+    @Test
+    void issuesAQwacCertificateFromAQwacCsr() throws Exception {
+        start("certificates:issue");
+        String csr = CertApiTestSupport.base64QwacCsr("psp.example.com");
+
+        HttpResponse<String> response = post("/v1/certificates", "active-token",
+                "{\"csr\":\"" + csr + "\",\"profile\":\"QWAC\"}");
+
+        assertThat(response.statusCode()).isEqualTo(201);
+        X509Certificate cert = parseCertificate(Json.MAPPER.readTree(response.body()));
+        assertThat(cert.getKeyUsage()[0]).as("digitalSignature").isTrue();
+        assertThat(cert.getKeyUsage()[2]).as("keyEncipherment").isTrue();
+        assertThat(cert.getExtendedKeyUsage()).as("QWAC has serverAuth+clientAuth")
+                .isNotNull();
+        // qCStatements extension (1.3.6.1.5.5.7.1.3) carried through from CSR.
+        assertThat(cert.getExtensionValue("1.3.6.1.5.5.7.1.3"))
+                .as("QWAC must carry qCStatements")
+                .isNotNull();
+    }
+
+    @Test
+    void rejectsNonCompliantQwacCsrAsBadRequest() throws Exception {
+        start("certificates:issue");
+        String csr = CertApiTestSupport.base64Csr("psp.example.com");
+
+        HttpResponse<String> response = post("/v1/certificates", "active-token",
+                "{\"csr\":\"" + csr + "\",\"profile\":\"QWAC\"}");
+
+        assertThat(response.statusCode()).isEqualTo(400);
+        JsonNode bodyJson = Json.MAPPER.readTree(response.body());
+        assertThat(bodyJson.get("error").asText()).isEqualTo("bad_csr");
+        assertThat(bodyJson.get("error_description").asText().toLowerCase())
+                .containsAnyOf("qwac", "organizationidentifier", "qccompliance");
+    }
+
+    @Test
     void rejectsBrsealOpensslConfigRequestWithTooFewOrganizationUnits() throws Exception {
         start("certificates:issue");
         String body = """

--- a/quick-pki-cert-api/src/test/java/com/elevenware/quickpki/certapi/CertApiTestSupport.java
+++ b/quick-pki-cert-api/src/test/java/com/elevenware/quickpki/certapi/CertApiTestSupport.java
@@ -1,6 +1,7 @@
 package com.elevenware.quickpki.certapi;
 
 import com.elevenware.quickpki.CertInfo;
+import com.elevenware.quickpki.EuQualified;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.ExtensionsGenerator;
@@ -88,6 +89,26 @@ final class CertApiTestSupport {
                 extGen.generate());
         ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(keyPair.getPrivate());
         PKCS10CertificationRequest csr = builder.build(signer);
+        return Base64.getEncoder().encodeToString(csr.getEncoded());
+    }
+
+    /**
+     * Builds a QWAC-compliant CSR via the {@link EuQualified} helper - subject
+     * in the ETSI EN 319 412-1 order, default qcStatements baked into the
+     * extensionRequest. Used by the cert-api round-trip tests that exercise
+     * issuance under the QWAC profile.
+     */
+    static String base64QwacCsr(String commonName) throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+        PKCS10CertificationRequest csr = EuQualified.qwac()
+                .country("GB")
+                .organization("Example PSP plc")
+                .organizationIdentifier(EuQualified.psd2OrganizationIdentifier("GB", "FCA", "123456"))
+                .commonName(commonName)
+                .dnsName(commonName)
+                .buildCsr(keyPair);
         return Base64.getEncoder().encodeToString(csr.getEncoded());
     }
 

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertInfo.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertInfo.java
@@ -23,6 +23,7 @@ public final class CertInfo {
     private final List<String> dnsNames;
     private final List<String> ipAddresses;
     private final List<GeneralName> otherSubjectAlternativeNames;
+    private final List<QcStatement> qcStatements;
     private final Set<KeyUsageBit> keyUsages;
     private final Set<ExtendedKeyUsageId> extendedKeyUsages;
     private final CertificateProfile profile;
@@ -34,6 +35,7 @@ public final class CertInfo {
         this.dnsNames = List.copyOf(builder.dnsNames);
         this.ipAddresses = List.copyOf(builder.ipAddresses);
         this.otherSubjectAlternativeNames = List.copyOf(builder.otherSubjectAlternativeNames);
+        this.qcStatements = List.copyOf(builder.qcStatements);
         // Never null: a CertInfo without an explicit profile behaves exactly
         // as QuickPki did before profiles existed.
         this.profile = builder.profile == null ? CertificateProfile.DEFAULT : builder.profile;
@@ -83,6 +85,12 @@ public final class CertInfo {
         for (GeneralName otherName : Csr.otherSubjectAlternativeNames(csr)) {
             builder.otherSubjectAlternativeName(otherName);
         }
+        // QC statements live in the CSR's extensionRequest the same way SANs
+        // do; carry them through so an EU qualified profile can be issued
+        // from a CSR the subscriber built with EuQualified.qwac()/qseal().
+        for (QcStatement statement : Csr.qcStatements(csr)) {
+            builder.qcStatement(statement);
+        }
         return builder;
     }
 
@@ -108,6 +116,14 @@ public final class CertInfo {
 
     public List<GeneralName> getOtherSubjectAlternativeNames() {
         return otherSubjectAlternativeNames;
+    }
+
+    /**
+     * QCStatements to emit in the leaf's {@code qCStatements} extension. Empty
+     * when the caller has set none; the extension is omitted in that case.
+     */
+    public List<QcStatement> getQcStatements() {
+        return qcStatements;
     }
 
     // Null when the caller hasn't expressed a preference (QuickPki picks an
@@ -139,6 +155,7 @@ public final class CertInfo {
                 && Objects.equals(dnsNames, that.dnsNames)
                 && Objects.equals(ipAddresses, that.ipAddresses)
                 && Objects.equals(otherSubjectAlternativeNames, that.otherSubjectAlternativeNames)
+                && Objects.equals(qcStatements, that.qcStatements)
                 && Objects.equals(keyUsages, that.keyUsages)
                 && Objects.equals(extendedKeyUsages, that.extendedKeyUsages)
                 && profile == that.profile;
@@ -147,7 +164,8 @@ public final class CertInfo {
     @Override
     public int hashCode() {
         return Objects.hash(subjectName, validFrom, validUntil, dnsNames,
-                ipAddresses, otherSubjectAlternativeNames, keyUsages, extendedKeyUsages, profile);
+                ipAddresses, otherSubjectAlternativeNames, qcStatements,
+                keyUsages, extendedKeyUsages, profile);
     }
 
     @Override
@@ -159,6 +177,7 @@ public final class CertInfo {
                 + ", dnsNames=" + dnsNames
                 + ", ipAddresses=" + ipAddresses
                 + ", otherSubjectAlternativeNames=" + otherSubjectAlternativeNames
+                + ", qcStatements=" + qcStatements
                 + ", keyUsages=" + keyUsages
                 + ", extendedKeyUsages=" + extendedKeyUsages
                 + ", profile=" + profile
@@ -172,6 +191,7 @@ public final class CertInfo {
         private final List<String> dnsNames = new ArrayList<>();
         private final List<String> ipAddresses = new ArrayList<>();
         private final List<GeneralName> otherSubjectAlternativeNames = new ArrayList<>();
+        private final List<QcStatement> qcStatements = new ArrayList<>();
         private EnumSet<KeyUsageBit> keyUsages;
         private EnumSet<ExtendedKeyUsageId> extendedKeyUsages;
         private CertificateProfile profile;
@@ -221,6 +241,17 @@ public final class CertInfo {
                         "subjectAlternativeName must be an otherName GeneralName");
             }
             this.otherSubjectAlternativeNames.add(name);
+            return this;
+        }
+
+        /**
+         * Adds a QCStatement (RFC 3739) to the leaf's {@code qCStatements}
+         * extension. Multiple calls append in the order they were made.
+         * {@link EuQualified} supplies factory methods for the standard ETSI
+         * and PSD2 statements.
+         */
+        public Builder qcStatement(QcStatement statement) {
+            this.qcStatements.add(Objects.requireNonNull(statement, "statement must not be null"));
             return this;
         }
 

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertificateProfile.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/CertificateProfile.java
@@ -19,6 +19,9 @@ import java.util.stream.Collectors;
  *
  * <p>{@link #BRCAC} and {@link #BRSEAL} model the transport and signing
  * certificate profiles from the Open Finance Brasil certificate standards.
+ * {@link #QWAC} and {@link #QSEAL} model the EU eIDAS / PSD2 Qualified Web
+ * Authentication and Qualified Electronic Seal profiles
+ * (ETSI EN 319 412-2/-3 and ETSI TS 119 495 for the PSD2 attribute set).
  */
 public enum CertificateProfile {
 
@@ -50,6 +53,30 @@ public enum CertificateProfile {
      * all. Used to sign message payloads (JWS) between participants.
      */
     BRSEAL(
+            EnumSet.of(KeyUsageBit.DIGITAL_SIGNATURE, KeyUsageBit.NON_REPUDIATION),
+            EnumSet.noneOf(ExtendedKeyUsageId.class)),
+
+    /**
+     * EU Qualified Web Authentication Certificate (QWAC): KeyUsage
+     * digitalSignature + keyEncipherment, ExtendedKeyUsage
+     * serverAuth + clientAuth. Used by PSPs under PSD2 to identify themselves
+     * to ASPSPs and to TPP clients during mutual TLS. Profile compliance also
+     * requires the standard ETSI QC statements (QcCompliance + QcType=web);
+     * {@link EuQualified#qwac()} emits them by default.
+     */
+    QWAC(
+            EnumSet.of(KeyUsageBit.DIGITAL_SIGNATURE, KeyUsageBit.KEY_ENCIPHERMENT),
+            EnumSet.of(ExtendedKeyUsageId.SERVER_AUTH, ExtendedKeyUsageId.CLIENT_AUTH)),
+
+    /**
+     * EU Qualified Electronic Seal Certificate (QSEAL): KeyUsage
+     * digitalSignature + nonRepudiation, and no ExtendedKeyUsage extension at
+     * all. Used to seal message payloads (eg. detached JWS signatures over
+     * PSD2 API messages). Profile compliance also requires the standard ETSI
+     * QC statements (QcCompliance + QcType=eseal); {@link EuQualified#qseal()}
+     * emits them by default.
+     */
+    QSEAL(
             EnumSet.of(KeyUsageBit.DIGITAL_SIGNATURE, KeyUsageBit.NON_REPUDIATION),
             EnumSet.noneOf(ExtendedKeyUsageId.class));
 

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/Csr.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/Csr.java
@@ -1,7 +1,10 @@
 package com.elevenware.quickpki;
 
+import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -92,14 +95,20 @@ public final class Csr {
             sans.add(new GeneralName(GeneralName.iPAddress, ipAddress));
         }
         sans.addAll(info.getOtherSubjectAlternativeNames());
-        if (!sans.isEmpty()) {
-            ExtensionsGenerator extGen = new ExtensionsGenerator();
-            try {
+        ExtensionsGenerator extGen = new ExtensionsGenerator();
+        try {
+            if (!sans.isEmpty()) {
                 extGen.addExtension(Extension.subjectAlternativeName, false,
                         new GeneralNames(sans.toArray(new GeneralName[0])));
-            } catch (IOException e) {
-                throw new QuickPkiException("Failed to build CSR subjectAltName extension", e);
             }
+            if (!info.getQcStatements().isEmpty()) {
+                extGen.addExtension(Extension.qCStatements, false,
+                        encodeQcStatements(info.getQcStatements()));
+            }
+        } catch (IOException e) {
+            throw new QuickPkiException("Failed to build CSR extensionRequest", e);
+        }
+        if (!extGen.isEmpty()) {
             builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extGen.generate());
         }
 
@@ -187,6 +196,24 @@ public final class Csr {
             for (String organizationUnit : info.getOrganizationUnits()) {
                 addRdnIfPresent(builder, BCStyle.OU, organizationUnit);
             }
+            addRdnIfPresent(builder, BCStyle.CN, info.getCommonName());
+            return builder.build();
+        }
+        if (effective == CertificateProfile.QWAC || effective == CertificateProfile.QSEAL) {
+            // ETSI EN 319 412-1 §5.1.2 / -3 §4.2 subject DN order for
+            // legal-person qualified certs. countryName first, then the EV
+            // attributes, then the organizationIdentifier required by
+            // ETSI EN 319 412-1 §5.1.4 (PSDxx-NCA-PSP for PSD2 contexts),
+            // commonName last.
+            addRdnIfPresent(builder, BCStyle.C, info.getCountry());
+            addRdnIfPresent(builder, BCStyle.ST, info.getStateOrProvince());
+            addRdnIfPresent(builder, BCStyle.L, info.getLocality());
+            addRdnIfPresent(builder, BCStyle.O, info.getOrganization());
+            for (String organizationUnit : info.getOrganizationUnits()) {
+                addRdnIfPresent(builder, BCStyle.OU, organizationUnit);
+            }
+            addRdnIfPresent(builder, BCStyle.SERIALNUMBER, info.getSerialNumber());
+            addRdnIfPresent(builder, BCStyle.ORGANIZATION_IDENTIFIER, info.getOrganizationIdentifier());
             addRdnIfPresent(builder, BCStyle.CN, info.getCommonName());
             return builder.build();
         }
@@ -306,6 +333,60 @@ public final class Csr {
      */
     public static List<String> ipSubjectAlternativeNames(PKCS10CertificationRequest csr) {
         return sansOfTag(csr, GeneralName.iPAddress);
+    }
+
+    /**
+     * Returns the QCStatements (RFC 3739) requested in the CSR's
+     * extensionRequest, preserving each statement's ASN.1 payload. Empty list
+     * when the CSR omitted the extension. Used by
+     * {@link CertInfo#fromCsr(PKCS10CertificationRequest)} to carry the EU
+     * qualified statements (QcCompliance, QcType, QcPDS, PSD2 qcStatement)
+     * through to the issued certificate.
+     */
+    public static List<QcStatement> qcStatements(PKCS10CertificationRequest csr) {
+        Objects.requireNonNull(csr, "csr must not be null");
+        Extensions extensions = csr.getRequestedExtensions();
+        if (extensions == null) {
+            return List.of();
+        }
+        Extension qcExt = extensions.getExtension(Extension.qCStatements);
+        if (qcExt == null) {
+            return List.of();
+        }
+        ASN1Sequence sequence;
+        try {
+            sequence = ASN1Sequence.getInstance(qcExt.getParsedValue());
+        } catch (Exception e) {
+            throw new QuickPkiException("CSR carries a malformed qCStatements extension", e);
+        }
+        List<QcStatement> result = new ArrayList<>(sequence.size());
+        for (int i = 0; i < sequence.size(); i++) {
+            ASN1Sequence stmt = ASN1Sequence.getInstance(sequence.getObjectAt(i));
+            ASN1ObjectIdentifier oid = ASN1ObjectIdentifier.getInstance(stmt.getObjectAt(0));
+            ASN1Encodable info = stmt.size() > 1 ? stmt.getObjectAt(1) : null;
+            result.add(new QcStatement(oid, info));
+        }
+        return List.copyOf(result);
+    }
+
+    /**
+     * Encodes a list of {@link QcStatement}s as the {@code SEQUENCE OF
+     * QCStatement} structure mandated by RFC 3739 §3.2.6, ready to wrap in an
+     * X.509 Extension value or hand to openssl as a {@code DER:} blob.
+     */
+    public static DERSequence encodeQcStatements(List<QcStatement> statements) {
+        ASN1Encodable[] entries = new ASN1Encodable[statements.size()];
+        for (int i = 0; i < statements.size(); i++) {
+            QcStatement s = statements.get(i);
+            if (s.statementInfo() == null) {
+                entries[i] = new DERSequence(s.statementId());
+            } else {
+                entries[i] = new DERSequence(new ASN1Encodable[] {
+                        s.statementId(), s.statementInfo()
+                });
+            }
+        }
+        return new DERSequence(entries);
     }
 
     /**

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/EuQualified.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/EuQualified.java
@@ -1,0 +1,578 @@
+package com.elevenware.quickpki;
+
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERIA5String;
+import org.bouncycastle.asn1.DERPrintableString;
+import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.DERUTF8String;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+
+import java.security.KeyPair;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Convenience builders for the EU eIDAS / PSD2 Qualified Web Authentication
+ * (QWAC) and Qualified Electronic Seal (QSEAL) certificate profiles. Each
+ * builder collects the subject attributes, SAN entries, and ETSI QC statements
+ * mandated by the relevant specs (ETSI EN 319 412-1/-2/-3, ETSI EN 319 412-5
+ * for the QC statements, and ETSI TS 119 495 for the PSD2 attribute set), then
+ * produces either a {@link CertInfo} (ready to hand to
+ * {@link QuickPki#issueCertificate(CertInfo)}) or a signed PKCS#10 CSR.
+ *
+ * <p>The builders default the QC statements every qualified leaf must carry
+ * (QcCompliance + QcType, web or eseal) so a minimal caller only has to supply
+ * the subject DN. Optional extras - the PSD2 qcStatement listing the PSP
+ * roles + NCA, QcPDS PDS-URL pointers, QcSSCD for QSEAL on a QSCD - are added
+ * via the dedicated fluent methods.
+ *
+ * <p>No validation runs in this class: the spec compliance check happens
+ * inside {@link QuickPki} at issuance time, so a builder will happily produce
+ * a partially-populated CertInfo or CSR. That mirrors how
+ * {@link OpenFinanceBrasil} behaves and lets ACME-style flows assemble a CSR
+ * client-side and let the issuing CA reject anything non-compliant with a
+ * single, consistent error path.
+ *
+ * <p>If you already have a fully-populated {@link SubjectName}, the
+ * {@link #qwacCertInfo(SubjectName)} / {@link #qsealCertInfo(SubjectName)}
+ * factories return a {@link CertInfo.Builder} pre-set with the right profile
+ * and the two mandatory QC statements so you can layer your own SAN entries
+ * and extra qcStatements on top without going through the fluent builders
+ * below.
+ */
+public final class EuQualified {
+
+    /** {@code id-pe-qcStatements} - the X.509 extension OID (RFC 3739 §3.2.6). */
+    public static final String OID_QC_STATEMENTS_EXTENSION = "1.3.6.1.5.5.7.1.3";
+
+    /** {@code id-etsi-qcs-QcCompliance} (ETSI EN 319 412-5 §4.2.1). */
+    public static final String OID_QC_COMPLIANCE = "0.4.0.1862.1.1";
+    /** {@code id-etsi-qcs-LimitValue} (ETSI EN 319 412-5 §4.3.2). */
+    public static final String OID_QC_LIMIT_VALUE = "0.4.0.1862.1.2";
+    /** {@code id-etsi-qcs-RetentionPeriod} (ETSI EN 319 412-5 §4.3.3). */
+    public static final String OID_QC_RETENTION_PERIOD = "0.4.0.1862.1.3";
+    /** {@code id-etsi-qcs-QcSSCD} - private key held on a QSCD (ETSI EN 319 412-5 §4.2.2). */
+    public static final String OID_QC_SSCD = "0.4.0.1862.1.4";
+    /** {@code id-etsi-qcs-QcPDS} - PKI Disclosure Statement URLs (ETSI EN 319 412-5 §4.3.4). */
+    public static final String OID_QC_PDS = "0.4.0.1862.1.5";
+    /** {@code id-etsi-qcs-QcType} (ETSI EN 319 412-5 §4.2.3). */
+    public static final String OID_QC_TYPE = "0.4.0.1862.1.6";
+
+    /** {@code id-etsi-qct-esign} - QcType value for electronic signatures (natural person). */
+    public static final String OID_QC_TYPE_ESIGN = "0.4.0.1862.1.6.1";
+    /** {@code id-etsi-qct-eseal} - QcType value for electronic seals (legal person; QSEAL). */
+    public static final String OID_QC_TYPE_ESEAL = "0.4.0.1862.1.6.2";
+    /** {@code id-etsi-qct-web} - QcType value for web authentication (QWAC). */
+    public static final String OID_QC_TYPE_WEB = "0.4.0.1862.1.6.3";
+
+    /** {@code id-etsi-psd2-qcStatement} (ETSI TS 119 495 §5.1). */
+    public static final String OID_PSD2_QC_STATEMENT = "0.4.0.19495.2";
+
+    private EuQualified() {}
+
+    /**
+     * The four PSD2 PSP roles defined by ETSI TS 119 495 §5.1. The OID is the
+     * machine-readable identifier carried in the {@code roleOfPspOid} field
+     * of the PSD2 qcStatement; {@link #abbreviation()} is the corresponding
+     * fixed string carried in {@code roleOfPspName}.
+     */
+    public enum Psd2Role {
+
+        /** Account Servicing Payment Service Provider. */
+        PSP_AS("0.4.0.19495.1.1", "PSP_AS"),
+        /** Payment Initiation Service Provider. */
+        PSP_PI("0.4.0.19495.1.2", "PSP_PI"),
+        /** Account Information Service Provider. */
+        PSP_AI("0.4.0.19495.1.3", "PSP_AI"),
+        /** Issuer of card-based payment instruments. */
+        PSP_IC("0.4.0.19495.1.4", "PSP_IC");
+
+        private final String oid;
+        private final String abbreviation;
+
+        Psd2Role(String oid, String abbreviation) {
+            this.oid = oid;
+            this.abbreviation = abbreviation;
+        }
+
+        public String oid() {
+            return oid;
+        }
+
+        public String abbreviation() {
+            return abbreviation;
+        }
+    }
+
+    /**
+     * A single PDS URL/language pair carried in a {@code QcPDS} qcStatement.
+     * The language must be an ISO 639-1 two-letter code (eg. {@code "en"});
+     * the URL is rendered as IA5String per ETSI EN 319 412-5.
+     */
+    public record PdsLocation(String url, String language) {
+        public PdsLocation {
+            Objects.requireNonNull(url, "url must not be null");
+            Objects.requireNonNull(language, "language must not be null");
+            if (language.length() != 2) {
+                throw new IllegalArgumentException(
+                        "PDS language must be a two-letter ISO 639-1 code (got '" + language + "')");
+            }
+        }
+    }
+
+    /** Starts a QWAC (transport / mTLS, server + client auth) certificate builder. */
+    public static QwacBuilder qwac() {
+        return new QwacBuilder();
+    }
+
+    /** Starts a QSEAL (legal-person seal, signs payloads) certificate builder. */
+    public static QsealBuilder qseal() {
+        return new QsealBuilder();
+    }
+
+    /**
+     * Returns a {@link CertInfo.Builder} with the QWAC profile pre-selected,
+     * the supplied SubjectName attached, and the two mandatory ETSI QC
+     * statements (QcCompliance + QcType=web) populated. The caller is
+     * responsible for adding the required DNS SAN entry / entries and any
+     * additional qcStatements (eg. PSD2, QcPDS) the deployment needs.
+     */
+    public static CertInfo.Builder qwacCertInfo(SubjectName subjectName) {
+        Objects.requireNonNull(subjectName, "subjectName must not be null");
+        return CertInfo.builder()
+                .profile(CertificateProfile.QWAC)
+                .subjectName(subjectName)
+                .qcStatement(qcCompliance())
+                .qcStatement(qcType(OID_QC_TYPE_WEB));
+    }
+
+    /**
+     * Returns a {@link CertInfo.Builder} with the QSEAL profile pre-selected,
+     * the supplied SubjectName attached, and the two mandatory ETSI QC
+     * statements (QcCompliance + QcType=eseal) populated.
+     */
+    public static CertInfo.Builder qsealCertInfo(SubjectName subjectName) {
+        Objects.requireNonNull(subjectName, "subjectName must not be null");
+        return CertInfo.builder()
+                .profile(CertificateProfile.QSEAL)
+                .subjectName(subjectName)
+                .qcStatement(qcCompliance())
+                .qcStatement(qcType(OID_QC_TYPE_ESEAL));
+    }
+
+    /**
+     * The {@code id-etsi-qcs-QcCompliance} statement that signals the leaf is
+     * a qualified certificate under Regulation (EU) 910/2014 (eIDAS).
+     */
+    public static QcStatement qcCompliance() {
+        return new QcStatement(new ASN1ObjectIdentifier(OID_QC_COMPLIANCE));
+    }
+
+    /**
+     * The {@code id-etsi-qcs-QcSSCD} statement that signals the corresponding
+     * private key is held on a Qualified Signature/Seal Creation Device.
+     */
+    public static QcStatement qcSSCD() {
+        return new QcStatement(new ASN1ObjectIdentifier(OID_QC_SSCD));
+    }
+
+    /**
+     * A {@code id-etsi-qcs-QcType} statement carrying the supplied QcType
+     * value OID. Use {@link #OID_QC_TYPE_WEB} for QWAC, {@link #OID_QC_TYPE_ESEAL}
+     * for QSEAL, {@link #OID_QC_TYPE_ESIGN} for natural-person eSign.
+     */
+    public static QcStatement qcType(String typeOid) {
+        Objects.requireNonNull(typeOid, "typeOid must not be null");
+        return new QcStatement(
+                new ASN1ObjectIdentifier(OID_QC_TYPE),
+                new DERSequence(new ASN1ObjectIdentifier(typeOid)));
+    }
+
+    /**
+     * A {@code id-etsi-qcs-QcPDS} statement listing one or more PKI
+     * Disclosure Statement URLs with their language.
+     */
+    public static QcStatement qcPds(List<PdsLocation> locations) {
+        Objects.requireNonNull(locations, "locations must not be null");
+        if (locations.isEmpty()) {
+            throw new IllegalArgumentException("qcPds requires at least one PdsLocation");
+        }
+        ASN1Encodable[] entries = new ASN1Encodable[locations.size()];
+        for (int i = 0; i < locations.size(); i++) {
+            PdsLocation loc = locations.get(i);
+            entries[i] = new DERSequence(new ASN1Encodable[] {
+                    new DERIA5String(loc.url()),
+                    new DERPrintableString(loc.language())
+            });
+        }
+        return new QcStatement(
+                new ASN1ObjectIdentifier(OID_QC_PDS),
+                new DERSequence(entries));
+    }
+
+    /**
+     * The {@code id-etsi-psd2-qcStatement} (ETSI TS 119 495 §5.1) carrying
+     * the PSP's roles and the supervising NCA's name and ID. PSD2 QWAC and
+     * QSEAL certificates issued under eIDAS for PSD2 use must carry this.
+     *
+     * @throws IllegalArgumentException if {@code roles} is empty
+     */
+    public static QcStatement psd2QcStatement(Set<Psd2Role> roles, String ncaName, String ncaId) {
+        Objects.requireNonNull(roles, "roles must not be null");
+        Objects.requireNonNull(ncaName, "ncaName must not be null");
+        Objects.requireNonNull(ncaId, "ncaId must not be null");
+        if (roles.isEmpty()) {
+            throw new IllegalArgumentException("psd2QcStatement requires at least one PSP role");
+        }
+        // Iteration order is enum-declaration order regardless of how the
+        // caller passed the set in, so the encoded payload is deterministic.
+        Set<Psd2Role> ordered = new LinkedHashSet<>(Arrays.asList(Psd2Role.values()));
+        ordered.retainAll(roles);
+        ASN1Encodable[] roleEntries = new ASN1Encodable[ordered.size()];
+        int i = 0;
+        for (Psd2Role role : ordered) {
+            roleEntries[i++] = new DERSequence(new ASN1Encodable[] {
+                    new ASN1ObjectIdentifier(role.oid()),
+                    new DERUTF8String(role.abbreviation())
+            });
+        }
+        DERSequence rolesSeq = new DERSequence(roleEntries);
+        DERSequence payload = new DERSequence(new ASN1Encodable[] {
+                rolesSeq,
+                new DERUTF8String(ncaName),
+                new DERUTF8String(ncaId)
+        });
+        return new QcStatement(new ASN1ObjectIdentifier(OID_PSD2_QC_STATEMENT), payload);
+    }
+
+    /**
+     * Formats an {@code organizationIdentifier} RDN value for a PSD2 PSP per
+     * ETSI TS 119 495 §5.2.1: {@code PSD{country}-{NCA-Id}-{PSP-Id}}, eg.
+     * {@code PSDGB-FCA-123456}. The country must be the two-letter ISO 3166-1
+     * code of the supervising authority's country.
+     */
+    public static String psd2OrganizationIdentifier(String country, String ncaId, String pspId) {
+        Objects.requireNonNull(country, "country must not be null");
+        Objects.requireNonNull(ncaId, "ncaId must not be null");
+        Objects.requireNonNull(pspId, "pspId must not be null");
+        if (country.length() != 2) {
+            throw new IllegalArgumentException(
+                    "country must be a two-letter ISO 3166-1 code (got '" + country + "')");
+        }
+        return "PSD" + country.toUpperCase(Locale.ROOT) + "-" + ncaId + "-" + pspId;
+    }
+
+    // --------------------------------------------------------------------
+    // QWAC builder
+    // --------------------------------------------------------------------
+
+    /**
+     * Fluent builder for the QWAC subject, SAN entries, and qcStatements.
+     * The two mandatory ETSI qcStatements (QcCompliance + QcType=web) are
+     * added by default; calling {@link #omitDefaultQcStatements()} drops them
+     * for tests that want to verify the issuance-time validation.
+     */
+    public static final class QwacBuilder {
+        private String commonName;
+        private String country;
+        private String stateOrProvince;
+        private String locality;
+        private String organization;
+        private String organizationIdentifier;
+        private final List<String> organizationUnits = new ArrayList<>();
+        private String serialNumber;
+        private final List<String> dnsNames = new ArrayList<>();
+        private final List<QcStatement> extraQcStatements = new ArrayList<>();
+        private boolean emitDefaultQcStatements = true;
+
+        private QwacBuilder() {}
+
+        /** Subject commonName; typically the transport hostname. */
+        public QwacBuilder commonName(String commonName) {
+            this.commonName = commonName;
+            return this;
+        }
+
+        /** Two-letter ISO 3166-1 country code, per ETSI EN 319 412-1 §5.1.2. */
+        public QwacBuilder country(String country) {
+            this.country = country;
+            return this;
+        }
+
+        public QwacBuilder stateOrProvince(String stateOrProvince) {
+            this.stateOrProvince = stateOrProvince;
+            return this;
+        }
+
+        public QwacBuilder locality(String locality) {
+            this.locality = locality;
+            return this;
+        }
+
+        /** Subject organizationName; the legal-person registered name. */
+        public QwacBuilder organization(String organization) {
+            this.organization = organization;
+            return this;
+        }
+
+        /**
+         * Subject organizationIdentifier (OID 2.5.4.97). For PSD2 use
+         * {@link #psd2OrganizationIdentifier(String, String, String)} to
+         * format it; for non-PSD2 deployments use the LEI/VAT/NTR prefix
+         * defined by ETSI EN 319 412-1 §5.1.4.
+         */
+        public QwacBuilder organizationIdentifier(String organizationIdentifier) {
+            this.organizationIdentifier = organizationIdentifier;
+            return this;
+        }
+
+        public QwacBuilder organizationUnit(String organizationUnit) {
+            this.organizationUnits.add(Objects.requireNonNull(organizationUnit,
+                    "organizationUnit must not be null"));
+            return this;
+        }
+
+        public QwacBuilder serialNumber(String serialNumber) {
+            this.serialNumber = serialNumber;
+            return this;
+        }
+
+        /** Adds a DNS subjectAltName. QWAC requires at least one. */
+        public QwacBuilder dnsName(String dnsName) {
+            this.dnsNames.add(Objects.requireNonNull(dnsName, "dnsName must not be null"));
+            return this;
+        }
+
+        /**
+         * Adds the PSD2 qcStatement to the leaf, listing the PSP's roles and
+         * the supervising NCA's name and ID. Required for any QWAC issued in
+         * a PSD2 context; ignored by non-PSD2 QWAC profiles.
+         */
+        public QwacBuilder psd2(Set<Psd2Role> roles, String ncaName, String ncaId) {
+            this.extraQcStatements.add(psd2QcStatement(roles, ncaName, ncaId));
+            return this;
+        }
+
+        /** Adds a {@code QcPDS} qcStatement with the supplied PDS URLs. */
+        public QwacBuilder qcPds(List<PdsLocation> locations) {
+            this.extraQcStatements.add(EuQualified.qcPds(locations));
+            return this;
+        }
+
+        /** Adds an arbitrary additional qcStatement (eg. QcLimitValue). */
+        public QwacBuilder qcStatement(QcStatement statement) {
+            this.extraQcStatements.add(Objects.requireNonNull(statement, "statement must not be null"));
+            return this;
+        }
+
+        /**
+         * Drops the two default qcStatements (QcCompliance + QcType=web).
+         * Intended for tests that want the validator to reject a non-compliant
+         * QWAC; production callers should not use this.
+         */
+        public QwacBuilder omitDefaultQcStatements() {
+            this.emitDefaultQcStatements = false;
+            return this;
+        }
+
+        public SubjectName subjectName() {
+            SubjectName.Builder builder = SubjectName.builder()
+                    .country(country)
+                    .stateOrProvince(stateOrProvince)
+                    .locality(locality)
+                    .organization(organization)
+                    .organizationIdentifier(organizationIdentifier)
+                    .serialNumber(serialNumber)
+                    .commonName(commonName);
+            for (String ou : organizationUnits) {
+                builder.addOrganizationUnit(ou);
+            }
+            return builder.build();
+        }
+
+        /**
+         * Builds a {@link CertInfo.Builder} pre-set with the QWAC profile, the
+         * assembled SubjectName, the DNS SAN entries, and every qcStatement
+         * (defaults + extras). Returned as a builder so callers can append
+         * validity windows, key usage overrides etc. before {@code build()}.
+         */
+        public CertInfo.Builder toCertInfo() {
+            CertInfo.Builder builder = CertInfo.builder()
+                    .profile(CertificateProfile.QWAC)
+                    .subjectName(subjectName());
+            for (String dnsName : dnsNames) {
+                builder.dnsName(dnsName);
+            }
+            if (emitDefaultQcStatements) {
+                builder.qcStatement(qcCompliance());
+                builder.qcStatement(qcType(OID_QC_TYPE_WEB));
+            }
+            for (QcStatement statement : extraQcStatements) {
+                builder.qcStatement(statement);
+            }
+            return builder;
+        }
+
+        public PKCS10CertificationRequest buildCsr(KeyPair keyPair) {
+            return Csr.create(toCertInfo().build(), keyPair);
+        }
+
+        public String buildCsrPem(KeyPair keyPair) {
+            return Csr.toPem(buildCsr(keyPair));
+        }
+    }
+
+    // --------------------------------------------------------------------
+    // QSEAL builder
+    // --------------------------------------------------------------------
+
+    /**
+     * Fluent builder for the QSEAL subject and qcStatements. The two
+     * mandatory ETSI qcStatements (QcCompliance + QcType=eseal) are added by
+     * default; call {@link #omitDefaultQcStatements()} to drop them.
+     */
+    public static final class QsealBuilder {
+        private String commonName;
+        private String country;
+        private String stateOrProvince;
+        private String locality;
+        private String organization;
+        private String organizationIdentifier;
+        private final List<String> organizationUnits = new ArrayList<>();
+        private String serialNumber;
+        private final List<QcStatement> extraQcStatements = new ArrayList<>();
+        private boolean emitDefaultQcStatements = true;
+        private boolean qscd;
+
+        private QsealBuilder() {}
+
+        public QsealBuilder commonName(String commonName) {
+            this.commonName = commonName;
+            return this;
+        }
+
+        public QsealBuilder country(String country) {
+            this.country = country;
+            return this;
+        }
+
+        public QsealBuilder stateOrProvince(String stateOrProvince) {
+            this.stateOrProvince = stateOrProvince;
+            return this;
+        }
+
+        public QsealBuilder locality(String locality) {
+            this.locality = locality;
+            return this;
+        }
+
+        public QsealBuilder organization(String organization) {
+            this.organization = organization;
+            return this;
+        }
+
+        public QsealBuilder organizationIdentifier(String organizationIdentifier) {
+            this.organizationIdentifier = organizationIdentifier;
+            return this;
+        }
+
+        public QsealBuilder organizationUnit(String organizationUnit) {
+            this.organizationUnits.add(Objects.requireNonNull(organizationUnit,
+                    "organizationUnit must not be null"));
+            return this;
+        }
+
+        public QsealBuilder serialNumber(String serialNumber) {
+            this.serialNumber = serialNumber;
+            return this;
+        }
+
+        /** See {@link QwacBuilder#psd2(Set, String, String)}. */
+        public QsealBuilder psd2(Set<Psd2Role> roles, String ncaName, String ncaId) {
+            this.extraQcStatements.add(psd2QcStatement(roles, ncaName, ncaId));
+            return this;
+        }
+
+        public QsealBuilder qcPds(List<PdsLocation> locations) {
+            this.extraQcStatements.add(EuQualified.qcPds(locations));
+            return this;
+        }
+
+        /**
+         * Marks the certificate as backed by a Qualified Signature/Seal
+         * Creation Device by emitting the {@code QcSSCD} qcStatement.
+         */
+        public QsealBuilder onQscd() {
+            this.qscd = true;
+            return this;
+        }
+
+        public QsealBuilder qcStatement(QcStatement statement) {
+            this.extraQcStatements.add(Objects.requireNonNull(statement, "statement must not be null"));
+            return this;
+        }
+
+        public QsealBuilder omitDefaultQcStatements() {
+            this.emitDefaultQcStatements = false;
+            return this;
+        }
+
+        public SubjectName subjectName() {
+            SubjectName.Builder builder = SubjectName.builder()
+                    .country(country)
+                    .stateOrProvince(stateOrProvince)
+                    .locality(locality)
+                    .organization(organization)
+                    .organizationIdentifier(organizationIdentifier)
+                    .serialNumber(serialNumber)
+                    .commonName(commonName);
+            for (String ou : organizationUnits) {
+                builder.addOrganizationUnit(ou);
+            }
+            return builder.build();
+        }
+
+        public CertInfo.Builder toCertInfo() {
+            CertInfo.Builder builder = CertInfo.builder()
+                    .profile(CertificateProfile.QSEAL)
+                    .subjectName(subjectName());
+            if (emitDefaultQcStatements) {
+                builder.qcStatement(qcCompliance());
+                builder.qcStatement(qcType(OID_QC_TYPE_ESEAL));
+            }
+            if (qscd) {
+                builder.qcStatement(qcSSCD());
+            }
+            for (QcStatement statement : extraQcStatements) {
+                builder.qcStatement(statement);
+            }
+            return builder;
+        }
+
+        public PKCS10CertificationRequest buildCsr(KeyPair keyPair) {
+            return Csr.create(toCertInfo().build(), keyPair);
+        }
+
+        public String buildCsrPem(KeyPair keyPair) {
+            return Csr.toPem(buildCsr(keyPair));
+        }
+    }
+
+    // Internal helper: expose the unmodifiable set of supported PSP role
+    // abbreviations to callers (eg. cert-api) that need to validate inbound
+    // role lists.
+    static Set<String> roleAbbreviations() {
+        Set<String> names = new LinkedHashSet<>();
+        for (Psd2Role role : Psd2Role.values()) {
+            names.add(role.abbreviation());
+        }
+        return Collections.unmodifiableSet(names);
+    }
+}

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/QcStatement.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/QcStatement.java
@@ -1,0 +1,71 @@
+package com.elevenware.quickpki;
+
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+
+import java.util.Objects;
+
+/**
+ * A single entry in the X.509 {@code qCStatements} extension (RFC 3739
+ * §3.2.6). A QCStatement is an OID with an optional ASN.1 payload whose
+ * structure is defined per-OID. Multiple statements form the extension value.
+ *
+ * <p>Held as an opaque {@link ASN1Encodable} so callers can carry both the
+ * payload-less statements (eg. {@code id-etsi-qcs-QcCompliance}) and the
+ * structured ones (eg. {@code id-etsi-qcs-QcType}, the PSD2 qcStatement)
+ * through the same type. Convenience constructors for the standard ETSI and
+ * PSD2 statements live on {@link EuQualified}.
+ */
+public final class QcStatement {
+
+    private final ASN1ObjectIdentifier statementId;
+    private final ASN1Encodable statementInfo;
+
+    /**
+     * A QCStatement with no statementInfo payload. Use for the boolean-style
+     * statements that signal compliance by their presence alone (eg.
+     * {@code id-etsi-qcs-QcCompliance}, {@code id-etsi-qcs-QcSSCD}).
+     */
+    public QcStatement(ASN1ObjectIdentifier statementId) {
+        this(statementId, null);
+    }
+
+    /**
+     * A QCStatement with a structured statementInfo payload. The payload's
+     * ASN.1 shape is fixed by the statementId per RFC 3739 / ETSI EN 319 412-5
+     * / ETSI TS 119 495.
+     */
+    public QcStatement(ASN1ObjectIdentifier statementId, ASN1Encodable statementInfo) {
+        this.statementId = Objects.requireNonNull(statementId, "statementId must not be null");
+        this.statementInfo = statementInfo;
+    }
+
+    public ASN1ObjectIdentifier statementId() {
+        return statementId;
+    }
+
+    /** {@code null} for the payload-less statements. */
+    public ASN1Encodable statementInfo() {
+        return statementInfo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof QcStatement that)) return false;
+        return statementId.equals(that.statementId)
+                && Objects.equals(statementInfo, that.statementInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(statementId, statementInfo);
+    }
+
+    @Override
+    public String toString() {
+        return "QcStatement{" + statementId.getId()
+                + (statementInfo == null ? "" : ", info=" + statementInfo)
+                + '}';
+    }
+}

--- a/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
+++ b/quick-pki-lib/src/main/java/com/elevenware/quickpki/QuickPki.java
@@ -479,6 +479,10 @@ public class QuickPki {
         if (sans != null) {
             certificateBuilder.addExtension(Extension.subjectAlternativeName, false, sans);
         }
+        if (!info.getQcStatements().isEmpty()) {
+            certificateBuilder.addExtension(Extension.qCStatements, false,
+                    Csr.encodeQcStatements(info.getQcStatements()));
+        }
 
         X509CertificateHolder rootCertHolder = certificateBuilder.build(rootCertContentSigner);
         X509Certificate cert = new JcaX509CertificateConverter().setProvider(provider).getCertificate(rootCertHolder);
@@ -510,18 +514,30 @@ public class QuickPki {
 
     private void validateProfileCompliance(CertInfo info, PublicKey publicKey) {
         CertificateProfile profile = info.getProfile();
-        if (profile != CertificateProfile.BRCAC && profile != CertificateProfile.BRSEAL) {
+        if (profile == CertificateProfile.BRCAC || profile == CertificateProfile.BRSEAL) {
+            validateOpenFinanceAlgorithm(publicKey);
+            SubjectName subjectName = info.getSubjectName();
+            if (subjectName == null) {
+                throw new IllegalArgumentException(profile + " certificates require an Open Finance subject DN");
+            }
+            if (profile == CertificateProfile.BRCAC) {
+                validateBrcac(info, subjectName);
+            } else {
+                validateBrseal(info, subjectName);
+            }
             return;
         }
-        validateOpenFinanceAlgorithm(publicKey);
-        SubjectName subjectName = info.getSubjectName();
-        if (subjectName == null) {
-            throw new IllegalArgumentException(profile + " certificates require an Open Finance subject DN");
-        }
-        if (profile == CertificateProfile.BRCAC) {
-            validateBrcac(info, subjectName);
-        } else {
-            validateBrseal(info, subjectName);
+        if (profile == CertificateProfile.QWAC || profile == CertificateProfile.QSEAL) {
+            validateEuQualifiedAlgorithm(publicKey);
+            SubjectName subjectName = info.getSubjectName();
+            if (subjectName == null) {
+                throw new IllegalArgumentException(profile + " certificates require an EU qualified subject DN");
+            }
+            if (profile == CertificateProfile.QWAC) {
+                validateQwac(info, subjectName);
+            } else {
+                validateQseal(info, subjectName);
+            }
         }
     }
 
@@ -591,6 +607,111 @@ public class QuickPki {
         if (!found) {
             throw new IllegalArgumentException("BRSEAL certificates require otherName " + oid);
         }
+    }
+
+    // ETSI EN 319 411-2 §6.6.1: qualified certs must use an algorithm and key
+    // size from the SOG-IS list. RSA must be ≥ 2048 bits; ECDSA must use a
+    // named curve in the P-256/P-384/P-521 family. The signature algorithm on
+    // the issued cert must use SHA-256 or stronger.
+    private void validateEuQualifiedAlgorithm(PublicKey publicKey) {
+        String algo = publicKey.getAlgorithm();
+        if ("RSA".equalsIgnoreCase(algo)) {
+            int bits = ((RSAPublicKey) publicKey).getModulus().bitLength();
+            if (bits < 2048) {
+                throw new IllegalArgumentException(
+                        "EU QWAC/QSEAL certificates require an RSA key of at least 2048 bits (got "
+                                + bits + ")");
+            }
+        } else if (!"EC".equalsIgnoreCase(algo) && !"ECDSA".equalsIgnoreCase(algo)) {
+            throw new IllegalArgumentException(
+                    "EU QWAC/QSEAL certificates require an RSA or ECDSA public key (got " + algo + ")");
+        }
+        String sigAlg = issuerInfo.getEffectiveSignatureAlgorithm();
+        if (sigAlg == null || !sigAlg.toUpperCase().contains("SHA256")
+                && !sigAlg.toUpperCase().contains("SHA384")
+                && !sigAlg.toUpperCase().contains("SHA512")) {
+            throw new IllegalArgumentException(
+                    "EU QWAC/QSEAL certificates require an issuer signature algorithm of "
+                            + "SHA-256 or stronger (got " + sigAlg + ")");
+        }
+    }
+
+    private void validateQwac(CertInfo info, SubjectName subjectName) {
+        validateEuQualifiedSubject(subjectName, "QWAC");
+        requireNonBlank(subjectName.getCommonName(), "commonName");
+        if (info.getDnsNames().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "QWAC certificates require at least one DNS subjectAltName");
+        }
+        if (!info.getIpAddresses().isEmpty() || !info.getOtherSubjectAlternativeNames().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "QWAC certificates support DNS subjectAltName entries only");
+        }
+        requireQcStatement(info, EuQualified.OID_QC_COMPLIANCE,
+                "QWAC certificates require the ETSI QcCompliance qcStatement (" + EuQualified.OID_QC_COMPLIANCE + ")");
+        requireQcType(info, EuQualified.OID_QC_TYPE_WEB,
+                "QWAC certificates require a QcType qcStatement listing id-etsi-qct-web ("
+                        + EuQualified.OID_QC_TYPE_WEB + ")");
+    }
+
+    private void validateQseal(CertInfo info, SubjectName subjectName) {
+        validateEuQualifiedSubject(subjectName, "QSEAL");
+        requireNonBlank(subjectName.getCommonName(), "commonName");
+        if (!info.getIpAddresses().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "QSEAL certificates do not support IP subjectAltName entries");
+        }
+        requireQcStatement(info, EuQualified.OID_QC_COMPLIANCE,
+                "QSEAL certificates require the ETSI QcCompliance qcStatement (" + EuQualified.OID_QC_COMPLIANCE + ")");
+        requireQcType(info, EuQualified.OID_QC_TYPE_ESEAL,
+                "QSEAL certificates require a QcType qcStatement listing id-etsi-qct-eseal ("
+                        + EuQualified.OID_QC_TYPE_ESEAL + ")");
+    }
+
+    private void validateEuQualifiedSubject(SubjectName subjectName, String profileName) {
+        requireNonBlank(subjectName.getCountry(), "country");
+        if (subjectName.getCountry().length() != 2) {
+            throw new IllegalArgumentException(
+                    profileName + " country must be a two-letter ISO 3166-1 code (got '"
+                            + subjectName.getCountry() + "')");
+        }
+        requireNonBlank(subjectName.getOrganization(), "organization");
+        requireNonBlank(subjectName.getOrganizationIdentifier(), "organizationIdentifier");
+        // ETSI EN 319 412-1 §5.1.4 fixes the syntax for legal-person
+        // organizationIdentifier; for PSD2 (TS 119 495 §5) it must be
+        // PSD{2-letter-country}-{NCA-Id}-{PSP-Id}. Accept either the ETSI
+        // prefixes (VAT/NTR/PSD/LEI) or any other non-blank value with a
+        // soft warning - issuance for non-PSD2 EU qualified certs is allowed.
+    }
+
+    private void requireQcStatement(CertInfo info, String oid, String message) {
+        ASN1ObjectIdentifier target = new ASN1ObjectIdentifier(oid);
+        boolean found = info.getQcStatements().stream()
+                .anyMatch(s -> target.equals(s.statementId()));
+        if (!found) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    private void requireQcType(CertInfo info, String typeOid, String message) {
+        ASN1ObjectIdentifier qcTypeOid = new ASN1ObjectIdentifier(EuQualified.OID_QC_TYPE);
+        ASN1ObjectIdentifier target = new ASN1ObjectIdentifier(typeOid);
+        for (QcStatement s : info.getQcStatements()) {
+            if (!qcTypeOid.equals(s.statementId()) || s.statementInfo() == null) {
+                continue;
+            }
+            try {
+                ASN1Sequence types = ASN1Sequence.getInstance(s.statementInfo());
+                for (int i = 0; i < types.size(); i++) {
+                    if (target.equals(ASN1ObjectIdentifier.getInstance(types.getObjectAt(i)))) {
+                        return;
+                    }
+                }
+            } catch (Exception ignored) {
+                // Malformed QcType payload: fall through to the throw below.
+            }
+        }
+        throw new IllegalArgumentException(message);
     }
 
     private String otherNameOid(GeneralName name) {

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/CsrBuilderTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/CsrBuilderTests.java
@@ -23,7 +23,9 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -266,6 +268,111 @@ public class CsrBuilderTests {
         CertInfo info = OpenFinanceBrasil.brsealCertInfo(subject).build();
         assertEquals(CertificateProfile.BRSEAL, info.getProfile());
         assertEquals(subject, info.getSubjectName());
+    }
+
+    @Test
+    void euQualifiedQwacBuilderProducesCsrInEtsiRdnOrder() throws Exception {
+        KeyPair keys = generateRsaKeyPair();
+
+        PKCS10CertificationRequest csr = EuQualified.qwac()
+                .country("GB")
+                .organization("Example PSP plc")
+                .organizationIdentifier(EuQualified.psd2OrganizationIdentifier("GB", "FCA", "123456"))
+                .commonName("psp.example.com")
+                .dnsName("psp.example.com")
+                .buildCsr(keys);
+
+        assertDoesNotThrow(() -> Csr.verifySignature(csr));
+
+        RDN[] rdns = csr.getSubject().getRDNs();
+        assertEquals(BCStyle.C, rdns[0].getFirst().getType());
+        assertEquals(BCStyle.O, rdns[1].getFirst().getType());
+        assertEquals(BCStyle.ORGANIZATION_IDENTIFIER, rdns[2].getFirst().getType());
+        assertEquals(BCStyle.CN, rdns[3].getFirst().getType());
+
+        assertEquals(List.of("psp.example.com"), Csr.dnsSubjectAlternativeNames(csr));
+        // The two mandatory ETSI qcStatements ride in the CSR's
+        // extensionRequest so the issuer can carry them through.
+        java.util.List<QcStatement> qcStatements = Csr.qcStatements(csr);
+        assertEquals(2, qcStatements.size());
+        assertEquals(EuQualified.OID_QC_COMPLIANCE, qcStatements.get(0).statementId().getId());
+        assertEquals(EuQualified.OID_QC_TYPE, qcStatements.get(1).statementId().getId());
+    }
+
+    @Test
+    void euQualifiedQwacBuilderCsrCanBeIssuedAsQwacCertificate() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+        KeyPair keys = generateRsaKeyPair();
+
+        PKCS10CertificationRequest csr = EuQualified.qwac()
+                .country("GB")
+                .organization("Example PSP plc")
+                .organizationIdentifier(EuQualified.psd2OrganizationIdentifier("GB", "FCA", "123456"))
+                .commonName("psp.example.com")
+                .dnsName("psp.example.com")
+                .psd2(Set.of(EuQualified.Psd2Role.PSP_AS), "Financial Conduct Authority", "GB-FCA")
+                .buildCsr(keys);
+
+        CertificateBundle bundle = pki.issueCertificate(csr,
+                CertInfo.fromCsr(csr).profile(CertificateProfile.QWAC).build());
+
+        X500Name subject = new JcaX509CertificateHolder(bundle.getCertificate()).getSubject();
+        assertEquals("PSDGB-FCA-123456",
+                subject.getRDNs(BCStyle.ORGANIZATION_IDENTIFIER)[0].getFirst().getValue().toString());
+        assertEquals("psp.example.com",
+                subject.getRDNs(BCStyle.CN)[0].getFirst().getValue().toString());
+        // QC statements (including the PSD2 one) survived the CSR round trip.
+        assertNotNull(bundle.getCertificate()
+                .getExtensionValue(EuQualified.OID_QC_STATEMENTS_EXTENSION));
+    }
+
+    @Test
+    void euQualifiedQsealBuilderCsrCanBeIssuedAsQsealCertificate() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+        KeyPair keys = generateRsaKeyPair();
+
+        PKCS10CertificationRequest csr = EuQualified.qseal()
+                .country("GB")
+                .organization("Example PSP plc")
+                .organizationIdentifier(EuQualified.psd2OrganizationIdentifier("GB", "FCA", "123456"))
+                .commonName("PSP Seal")
+                .onQscd()
+                .buildCsr(keys);
+
+        CertificateBundle bundle = pki.issueCertificate(csr,
+                CertInfo.fromCsr(csr).profile(CertificateProfile.QSEAL).build());
+
+        // QSEAL forbids ExtendedKeyUsage and requires nonRepudiation.
+        assertTrue(bundle.getCertificate().getKeyUsage()[1], "QSEAL must assert nonRepudiation");
+        assertNotNull(bundle.getCertificate()
+                .getExtensionValue(EuQualified.OID_QC_STATEMENTS_EXTENSION));
+    }
+
+    @Test
+    void qwacCertInfoFactoryAttachesProfileSubjectAndDefaultQcStatements() {
+        SubjectName subject = SubjectName.builder()
+                .country("GB").organization("Example PSP plc")
+                .organizationIdentifier("PSDGB-FCA-123456")
+                .commonName("psp.example.com").build();
+
+        CertInfo info = EuQualified.qwacCertInfo(subject).dnsName("psp.example.com").build();
+
+        assertEquals(CertificateProfile.QWAC, info.getProfile());
+        assertEquals(subject, info.getSubjectName());
+        assertEquals(2, info.getQcStatements().size());
+    }
+
+    @Test
+    void qsealCertInfoFactoryAttachesProfileSubjectAndDefaultQcStatements() {
+        SubjectName subject = SubjectName.builder()
+                .country("GB").organization("Example PSP plc")
+                .organizationIdentifier("PSDGB-FCA-123456")
+                .commonName("PSP Seal").build();
+
+        CertInfo info = EuQualified.qsealCertInfo(subject).build();
+
+        assertEquals(CertificateProfile.QSEAL, info.getProfile());
+        assertEquals(2, info.getQcStatements().size());
     }
 
     @Test

--- a/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
+++ b/quick-pki-lib/src/test/java/com/elevenware/quickpki/PkiTests.java
@@ -1719,6 +1719,247 @@ public class PkiTests {
                 .build();
     }
 
+    // ----- QWAC / QSEAL profile coverage -----
+
+    @Test
+    void qwacProfileSetsTransportKeyUsageAndServerClientAuth() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+
+        CertificateBundle bundle = pki.issueCertificate(qwacInfo("psp.example.com").build());
+
+        boolean[] keyUsage = bundle.getCertificate().getKeyUsage();
+        assertNotNull(keyUsage, "QWAC leaf must have a KeyUsage extension");
+        assertTrue(keyUsage[0], "QWAC must assert digitalSignature");
+        assertTrue(keyUsage[2], "QWAC must assert keyEncipherment");
+
+        List<String> eku = bundle.getCertificate().getExtendedKeyUsage();
+        assertNotNull(eku, "QWAC must have an ExtendedKeyUsage extension");
+        assertTrue(eku.contains(KeyPurposeId.id_kp_serverAuth.getId()));
+        assertTrue(eku.contains(KeyPurposeId.id_kp_clientAuth.getId()));
+    }
+
+    @Test
+    void qsealProfileSetsSigningKeyUsageAndOmitsExtendedKeyUsage() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+
+        CertificateBundle bundle = pki.issueCertificate(qsealInfo("PSP Seal").build());
+
+        boolean[] keyUsage = bundle.getCertificate().getKeyUsage();
+        assertNotNull(keyUsage, "QSEAL leaf must have a KeyUsage extension");
+        assertTrue(keyUsage[0], "QSEAL must assert digitalSignature");
+        assertTrue(keyUsage[1], "QSEAL must assert nonRepudiation");
+        assertFalse(keyUsage[2], "QSEAL must NOT assert keyEncipherment");
+
+        assertNull(bundle.getCertificate().getExtendedKeyUsage(),
+                "QSEAL must carry no ExtendedKeyUsage extension");
+    }
+
+    @Test
+    void qwacCertificateCarriesEtsiQcStatementsExtension() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+
+        CertificateBundle bundle = pki.issueCertificate(qwacInfo("psp.example.com").build());
+
+        byte[] qcExt = bundle.getCertificate().getExtensionValue(EuQualified.OID_QC_STATEMENTS_EXTENSION);
+        assertNotNull(qcExt, "QWAC must carry the qCStatements extension (1.3.6.1.5.5.7.1.3)");
+        Set<String> statementOids = extractQcStatementOids(qcExt);
+        assertTrue(statementOids.contains(EuQualified.OID_QC_COMPLIANCE),
+                "QWAC must include QcCompliance, got " + statementOids);
+        assertTrue(statementOids.contains(EuQualified.OID_QC_TYPE),
+                "QWAC must include QcType, got " + statementOids);
+    }
+
+    @Test
+    void qsealCertificateCarriesQcTypeESeal() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+
+        CertificateBundle bundle = pki.issueCertificate(qsealInfo("PSP Seal").build());
+
+        byte[] qcExt = bundle.getCertificate().getExtensionValue(EuQualified.OID_QC_STATEMENTS_EXTENSION);
+        assertNotNull(qcExt, "QSEAL must carry the qCStatements extension");
+        assertTrue(qcTypeValuesOf(qcExt).contains(EuQualified.OID_QC_TYPE_ESEAL),
+                "QSEAL QcType must reference id-etsi-qct-eseal");
+    }
+
+    @Test
+    void qwacProfileRejectsMissingQcCompliance() {
+        QuickPki pki = QuickPki.createDefault();
+
+        // Build a QWAC CertInfo but strip the default qcStatements at the
+        // builder level - validator must reject.
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> pki.issueCertificate(EuQualified.qwac()
+                        .country("GB")
+                        .organization("Example PSP plc")
+                        .organizationIdentifier(EuQualified.psd2OrganizationIdentifier("GB", "FCA", "123456"))
+                        .commonName("psp.example.com")
+                        .dnsName("psp.example.com")
+                        .omitDefaultQcStatements()
+                        .toCertInfo().build()));
+
+        assertTrue(ex.getMessage().contains("QcCompliance"),
+                "message should call out the missing QcCompliance statement, got: " + ex.getMessage());
+    }
+
+    @Test
+    void qwacProfileRejectsMissingOrganizationIdentifier() {
+        QuickPki pki = QuickPki.createDefault();
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> pki.issueCertificate(EuQualified.qwac()
+                        .country("GB")
+                        .organization("Example PSP plc")
+                        .commonName("psp.example.com")
+                        .dnsName("psp.example.com")
+                        .toCertInfo().build()));
+
+        assertTrue(ex.getMessage().toLowerCase().contains("organizationidentifier"),
+                "message should call out the missing organizationIdentifier, got: " + ex.getMessage());
+    }
+
+    @Test
+    void qwacProfileRejectsMissingDnsSubjectAltName() {
+        QuickPki pki = QuickPki.createDefault();
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> pki.issueCertificate(EuQualified.qwac()
+                        .country("GB")
+                        .organization("Example PSP plc")
+                        .organizationIdentifier(EuQualified.psd2OrganizationIdentifier("GB", "FCA", "123456"))
+                        .commonName("psp.example.com")
+                        .toCertInfo().build()));
+
+        assertTrue(ex.getMessage().toLowerCase().contains("dns"),
+                "message should explain the missing DNS SAN, got: " + ex.getMessage());
+    }
+
+    @Test
+    void qwacProfileRejectsRsaKeySmallerThan2048() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(1024);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> pki.issueCertificate(qwacInfo("psp.example.com").build(),
+                        generator.generateKeyPair().getPublic()));
+
+        assertTrue(ex.getMessage().contains("2048"),
+                "message should call out the 2048-bit floor, got: " + ex.getMessage());
+    }
+
+    @Test
+    void qsealCertificateCarriesPsd2QcStatementWhenRequested() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+
+        CertInfo info = EuQualified.qseal()
+                .country("GB")
+                .organization("Example PSP plc")
+                .organizationIdentifier(EuQualified.psd2OrganizationIdentifier("GB", "FCA", "123456"))
+                .commonName("PSP Seal")
+                .psd2(Set.of(EuQualified.Psd2Role.PSP_AS, EuQualified.Psd2Role.PSP_AI),
+                        "Financial Conduct Authority", "GB-FCA")
+                .onQscd()
+                .toCertInfo().build();
+
+        CertificateBundle bundle = pki.issueCertificate(info);
+
+        byte[] qcExt = bundle.getCertificate().getExtensionValue(EuQualified.OID_QC_STATEMENTS_EXTENSION);
+        Set<String> oids = extractQcStatementOids(qcExt);
+        assertTrue(oids.contains(EuQualified.OID_PSD2_QC_STATEMENT),
+                "expected PSD2 qcStatement OID present, got " + oids);
+        assertTrue(oids.contains(EuQualified.OID_QC_SSCD),
+                "expected QcSSCD OID present (onQscd was called), got " + oids);
+    }
+
+    @Test
+    void qwacSubjectRdnsFollowEtsiOrder() throws Exception {
+        QuickPki pki = QuickPki.createDefault();
+        X500Name subject = new JcaX509CertificateHolder(
+                pki.issueCertificate(qwacInfo("psp.example.com").build()).getCertificate())
+                .getSubject();
+
+        org.bouncycastle.asn1.x500.RDN[] rdns = subject.getRDNs();
+        assertEquals(BCStyle.C, rdns[0].getFirst().getType());
+        assertEquals(BCStyle.O, rdns[1].getFirst().getType());
+        assertEquals(BCStyle.ORGANIZATION_IDENTIFIER, rdns[2].getFirst().getType());
+        assertEquals(BCStyle.CN, rdns[3].getFirst().getType());
+    }
+
+    @Test
+    void psd2OrganizationIdentifierFormatsAsTs119495() {
+        assertEquals("PSDGB-FCA-123456",
+                EuQualified.psd2OrganizationIdentifier("GB", "FCA", "123456"));
+        assertEquals("PSDDE-BAFIN-987654",
+                EuQualified.psd2OrganizationIdentifier("de", "BAFIN", "987654"));
+        assertThrows(IllegalArgumentException.class,
+                () -> EuQualified.psd2OrganizationIdentifier("GBR", "FCA", "123456"));
+    }
+
+    @Test
+    void certificateProfileEnumIncludesQwacAndQseal() {
+        assertEquals(CertificateProfile.QWAC, CertificateProfile.fromName("qwac"));
+        assertEquals(CertificateProfile.QSEAL, CertificateProfile.fromName("QSEAL"));
+    }
+
+    private static CertInfo.Builder qwacInfo(String commonName) {
+        return EuQualified.qwac()
+                .country("GB")
+                .organization("Example PSP plc")
+                .organizationIdentifier(EuQualified.psd2OrganizationIdentifier("GB", "FCA", "123456"))
+                .commonName(commonName)
+                .dnsName(commonName)
+                .toCertInfo();
+    }
+
+    private static CertInfo.Builder qsealInfo(String commonName) {
+        return EuQualified.qseal()
+                .country("GB")
+                .organization("Example PSP plc")
+                .organizationIdentifier(EuQualified.psd2OrganizationIdentifier("GB", "FCA", "123456"))
+                .commonName(commonName)
+                .toCertInfo();
+    }
+
+    private static Set<String> extractQcStatementOids(byte[] extensionValue) throws IOException {
+        // Strip the OCTET STRING wrapper that getExtensionValue() returns.
+        org.bouncycastle.asn1.ASN1OctetString wrapper =
+                org.bouncycastle.asn1.ASN1OctetString.getInstance(extensionValue);
+        org.bouncycastle.asn1.ASN1Sequence sequence =
+                org.bouncycastle.asn1.ASN1Sequence.getInstance(wrapper.getOctets());
+        Set<String> oids = new HashSet<>();
+        for (int i = 0; i < sequence.size(); i++) {
+            org.bouncycastle.asn1.ASN1Sequence stmt =
+                    org.bouncycastle.asn1.ASN1Sequence.getInstance(sequence.getObjectAt(i));
+            oids.add(org.bouncycastle.asn1.ASN1ObjectIdentifier.getInstance(stmt.getObjectAt(0)).getId());
+        }
+        return oids;
+    }
+
+    private static Set<String> qcTypeValuesOf(byte[] extensionValue) throws IOException {
+        org.bouncycastle.asn1.ASN1OctetString wrapper =
+                org.bouncycastle.asn1.ASN1OctetString.getInstance(extensionValue);
+        org.bouncycastle.asn1.ASN1Sequence sequence =
+                org.bouncycastle.asn1.ASN1Sequence.getInstance(wrapper.getOctets());
+        Set<String> values = new HashSet<>();
+        for (int i = 0; i < sequence.size(); i++) {
+            org.bouncycastle.asn1.ASN1Sequence stmt =
+                    org.bouncycastle.asn1.ASN1Sequence.getInstance(sequence.getObjectAt(i));
+            if (!EuQualified.OID_QC_TYPE.equals(
+                    org.bouncycastle.asn1.ASN1ObjectIdentifier.getInstance(stmt.getObjectAt(0)).getId())) {
+                continue;
+            }
+            if (stmt.size() < 2) {
+                continue;
+            }
+            org.bouncycastle.asn1.ASN1Sequence types =
+                    org.bouncycastle.asn1.ASN1Sequence.getInstance(stmt.getObjectAt(1));
+            for (int j = 0; j < types.size(); j++) {
+                values.add(org.bouncycastle.asn1.ASN1ObjectIdentifier.getInstance(types.getObjectAt(j)).getId());
+            }
+        }
+        return values;
+    }
+
     @BeforeAll
     static void setup() {
         Security.addProvider(new BouncyCastleProvider());


### PR DESCRIPTION
## Summary

Mirrors the recent Open Finance Brasil BRCAC/BRSEAL work for the EU eIDAS / PSD2 **Qualified Web Authentication** (QWAC) and **Qualified Electronic Seal** (QSEAL) profiles — profile support in the lib, plus consumer-facing helpers and a cert-api surface that matches the BRCAC/BRSEAL endpoints.

References: ETSI EN 319 412-1/-2/-3 (subject DN), ETSI EN 319 412-5 (QC statements), ETSI TS 119 495 (PSD2 attribute set and organizationIdentifier syntax).

### Library (`quick-pki-lib`)

- `CertificateProfile.QWAC` / `CertificateProfile.QSEAL` with the correct KeyUsage + ExtendedKeyUsage defaults (QWAC: digitalSignature + keyEncipherment, serverAuth + clientAuth; QSEAL: digitalSignature + nonRepudiation, no EKU).
- New `QcStatement` value type, `CertInfo.Builder.qcStatement(...)`, and CSR round-trip of the `qCStatements` extension via `Csr.qcStatements(...)`.
- `QuickPki` emits the `qCStatements` X.509 extension (1.3.6.1.5.5.7.1.3) on issued certs when present, and validates QWAC/QSEAL subject DN, SAN constraints, RSA ≥ 2048 / ECDSA key requirement, and presence of the mandatory ETSI QcCompliance + QcType statements.
- `Csr.x500Name` emits the ETSI EN 319 412-1 RDN order for the qualified profiles.
- New `EuQualified` helper class mirrors `OpenFinanceBrasil`:
  - `qwac()` / `qseal()` fluent builders, `qwacCertInfo()` / `qsealCertInfo()` factories
  - QC statement constructors: `qcCompliance()`, `qcType(typeOid)`, `qcSSCD()`, `qcPds(locations)`, `psd2QcStatement(roles, ncaName, ncaId)`
  - `Psd2Role` enum (PSP_AS / PSP_PI / PSP_AI / PSP_IC) with role OIDs
  - `PdsLocation` record for QcPDS URL/language pairs
  - `psd2OrganizationIdentifier(country, ncaId, pspId)` formatter producing `PSD{country}-{NCA-Id}-{PSP-Id}`
  - Public OID constants (`OID_QC_COMPLIANCE`, `OID_QC_TYPE_WEB`, `OID_QC_TYPE_ESEAL`, `OID_PSD2_QC_STATEMENT`, etc.)

### cert-api (`quick-pki-cert-api`)

- `POST /v1/openssl-configs/qwac` and `/v1/openssl-configs/qseal` generate openssl `req` configs with the subject DN, key usage / EKU, SANs and a pre-encoded DER `qCStatements` blob (including PSD2 + QcPDS + QcSSCD when requested).
- `POST /v1/certificates` already routes on `profile`, so `profile=QWAC` / `profile=QSEAL` work out of the box and reject non-compliant CSRs with `bad_csr`.
- The ACME server's existing `ACME_CERTIFICATE_PROFILE` env var picks up the new profiles via `CertificateProfile.fromName(...)` — no ACME-side changes needed.
- OpenAPI document updated with the new endpoints, request schemas (`QwacOpensslConfigRequest`, `QsealOpensslConfigRequest`, `PdsLocation`), and `QWAC` / `QSEAL` added to the profile enum.

### Tests

- 12 new lib tests covering KU/EKU emission, QC statements extension shape, validation rejections (missing QcCompliance, missing organizationIdentifier, missing DNS SAN, RSA < 2048), RDN ordering, PSD2 organizationIdentifier formatter and enum lookup.
- 5 new CSR builder tests covering the QWAC/QSEAL helpers and CertInfo round-trip from CSRs that include qcStatements.
- 9 new cert-api tests covering the new openssl-config endpoints (success + validation + auth), QWAC issuance round-trip, and rejection of non-compliant CSRs.

Total: **151 tests passing** (was 125 before).

## Test plan

- [x] `mvn test` across all three modules: 151 passing
- [ ] Hit `POST /v1/openssl-configs/qwac` and `POST /v1/openssl-configs/qseal` with a sample body; pipe the returned config into `openssl req -new -config ...` and confirm the resulting CSR carries the expected subject + qCStatements
- [ ] Issue a QWAC via `POST /v1/certificates` with `profile=QWAC` and confirm the certificate carries the qCStatements extension (`openssl x509 -text` → look for `1.3.6.1.5.5.7.1.3`)
- [ ] Smoke-test the ACME server with `ACME_CERTIFICATE_PROFILE=QWAC` against a CSR built with `EuQualified.qwac()`

https://claude.ai/code/session_015AzPh6rhsSQ3zQZFp6iJxi

---
_Generated by [Claude Code](https://claude.ai/code/session_015AzPh6rhsSQ3zQZFp6iJxi)_